### PR TITLE
第一阶段 UI 修整

### DIFF
--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -2847,7 +2847,9 @@ fun CourseScheduleAppUi(
             if (screen is Screen.Home || screen is Screen.Config) {
                 DockEntranceContainer(
                     phase = startupPhase,
-                    modifier = Modifier.align(Alignment.BottomStart)
+                    modifier = Modifier
+                        .align(Alignment.BottomStart)
+                        .zIndex(100f)
                 ) {
                     FloatingDock(
                         selected = screen,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -88,9 +88,6 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Colorize
-import androidx.compose.material.icons.filled.Palette
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -5504,6 +5501,7 @@ private fun tonalPreviewColors(seed: Long): List<ComposeColor> {
 @Composable
 private fun CourseColorModeRow(
     title: String,
+    iconRes: Int,
     mode: CourseCardColorMode,
     selectedMode: CourseCardColorMode,
     presets: List<List<Long>>,
@@ -5512,6 +5510,7 @@ private fun CourseColorModeRow(
     onOpenPalette: () -> Unit
 ) {
     val foreground = LocalContentColor.current
+    val labelColor = if (selectedMode == mode) MaterialTheme.colorScheme.primary else foreground
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -5519,13 +5518,26 @@ private fun CourseColorModeRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Text(
-            text = title,
+        Row(
             modifier = Modifier.width(42.dp),
-            color = if (selectedMode == mode) MaterialTheme.colorScheme.primary else foreground,
-            style = MaterialTheme.typography.labelMedium,
-            fontWeight = if (selectedMode == mode) FontWeight.Bold else FontWeight.Medium
-        )
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                painter = painterResource(iconRes),
+                contentDescription = null,
+                tint = labelColor,
+                modifier = Modifier.size(14.dp)
+            )
+            Text(
+                text = title,
+                color = labelColor,
+                style = MaterialTheme.typography.labelMedium,
+                fontWeight = if (selectedMode == mode) FontWeight.Bold else FontWeight.Medium,
+                maxLines = 1,
+                softWrap = false
+            )
+        }
         Row(
             modifier = Modifier.weight(1f),
             horizontalArrangement = if (mode == CourseCardColorMode.COLORFUL) {
@@ -5577,24 +5589,18 @@ private fun CourseColorModeRow(
             Surface(
                 modifier = Modifier.size(32.dp),
                 shape = RoundedCornerShape(50),
-                color = ComposeColor.Transparent,
+                color = foreground.copy(alpha = 0.10f),
                 border = null,
                 onClick = onOpenPalette
             ) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.sweepGradient(
-                                AutomaticColorfulCoursePreview.map { vividPreviewColor(it) }
-                            )
-                        ),
+                    modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.Palette,
+                        painter = painterResource(R.drawable.ic_color_palette_ring),
                         contentDescription = "自定义课程卡颜色",
-                        tint = if (foreground.luminance() > 0.5f) ComposeColor.White else ComposeColor.Black,
+                        tint = foreground,
                         modifier = Modifier.size(19.dp)
                     )
                 }
@@ -5636,7 +5642,7 @@ private fun CourseColorEditorDialog(
                     modifier = Modifier.size(38.dp)
                 ) {
                     Icon(
-                        imageVector = Icons.Filled.Colorize,
+                        painter = painterResource(R.drawable.ic_color_eyedropper),
                         contentDescription = "从壁纸吸色",
                         tint = foreground,
                         modifier = Modifier.size(21.dp)
@@ -6199,6 +6205,7 @@ fun PersonalizePanel(
                 Spacer(Modifier.height(8.dp))
                 CourseColorModeRow(
                     title = "纯色",
+                    iconRes = R.drawable.ic_color_solid,
                     mode = CourseCardColorMode.SOLID,
                     selectedMode = state.config.courseCardColorMode,
                     presets = SolidCourseColorPresets.map { listOf(it) },
@@ -6216,6 +6223,7 @@ fun PersonalizePanel(
                 )
                 CourseColorModeRow(
                     title = "渐变",
+                    iconRes = R.drawable.ic_color_gradient,
                     mode = CourseCardColorMode.GRADIENT,
                     selectedMode = state.config.courseCardColorMode,
                     presets = GradientCourseColorPresets.map { listOf(it) },
@@ -6233,6 +6241,7 @@ fun PersonalizePanel(
                 )
                 CourseColorModeRow(
                     title = "彩色",
+                    iconRes = R.drawable.ic_color_colorful,
                     mode = CourseCardColorMode.COLORFUL,
                     selectedMode = state.config.courseCardColorMode,
                     presets = listOf(AutomaticColorfulCoursePreview),

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDesignTokens.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDesignTokens.kt
@@ -65,10 +65,12 @@ object SleepDownDesignTokens {
         val AlertSingleLineActionSpacing = 18.dp
         // Single-row-action alerts are tightened only through their copy band. Their action row
         // keeps the accepted height, spacing and edge inset.
-        val CompactAlertTopInset = 28.dp
-        val CompactTitleContentSpacing = 11.dp
+        val CompactAlertTopInset = 24.dp
+        val CompactTitleContentSpacing = 9.dp
+        val CompactMultilineAlertTopInset = 28.dp
+        val CompactMultilineTitleContentSpacing = 11.dp
         val CompactMessageActionSpacing = 27.dp
-        val CompactSingleLineActionSpacing = 16.dp
+        val CompactSingleLineActionSpacing = 10.dp
         // A title plus a two-line message keeps its measured shell and action row unchanged; only
         // the copy is optically lifted so the extra line does not make the upper half look heavy.
         val ThreeLineAlertTextLift = 3.dp

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDialog.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDialog.kt
@@ -300,11 +300,12 @@ private fun LiquidAlertContent(
     // Alerts own their material tint, so their foreground must follow that stable surface rather
     // than the wallpaper behind the dim layer.
     val foreground = sleepDownPanelForegroundColor(config)
-    // One- and two-action alerts share the accepted single-row action layout. Tighten that whole
-    // family through the copy band only; action geometry and bottom/side insets stay unchanged.
+    // One- and two-action alerts share the accepted single-row action layout. Only their
+    // single-line copy path tightens; action geometry and bottom/side insets stay unchanged.
     var messageLineCount by remember(message) { mutableStateOf(0) }
     val messageSingleLine = messageLineCount == 1
     val compact = actions.size <= 2
+    val compactSingleLine = compact && messageSingleLine
     val copyLift = if (messageLineCount == 2) {
         -SleepDownDesignTokens.CenteredDialog.ThreeLineAlertTextLift
     } else {
@@ -312,8 +313,10 @@ private fun LiquidAlertContent(
     }
     Column(
         modifier = modifier.padding(
-            top = (if (compact) {
+            top = (if (compactSingleLine) {
                 SleepDownDesignTokens.CenteredDialog.CompactAlertTopInset
+            } else if (compact) {
+                SleepDownDesignTokens.CenteredDialog.CompactMultilineAlertTopInset
             } else {
                 SleepDownDesignTokens.CenteredDialog.AlertTopInset
             }) -
@@ -333,8 +336,10 @@ private fun LiquidAlertContent(
         )
         Spacer(
             Modifier.height(
-                if (compact) {
+                if (compactSingleLine) {
                     SleepDownDesignTokens.CenteredDialog.CompactTitleContentSpacing
+                } else if (compact) {
+                    SleepDownDesignTokens.CenteredDialog.CompactMultilineTitleContentSpacing
                 } else {
                     SleepDownDesignTokens.CenteredDialog.TitleContentSpacing
                 }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixPopup.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixPopup.kt
@@ -3,8 +3,6 @@ package com.xiaomanjun.sleepdownschedule.core.ui.settings
 import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
 import com.xiaomanjun.sleepdownschedule.glass.GlassBackdropDomain
 import com.xiaomanjun.sleepdownschedule.glass.GlassEffectFrame
-import com.xiaomanjun.sleepdownschedule.glass.GlassHighlightFrame
-import com.xiaomanjun.sleepdownschedule.glass.GlassHighlightStyle
 import com.xiaomanjun.sleepdownschedule.glass.GlassMaterialRole
 import com.xiaomanjun.sleepdownschedule.glass.GlassMaterialSpec
 import com.xiaomanjun.sleepdownschedule.glass.rememberGlassSurfaceDescriptor
@@ -24,6 +22,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -108,15 +107,17 @@ private fun Modifier.miuixCascadingPopupSurface(
         return background(if (dark) Color(0xFF242424) else Color.White)
     }
     val effectiveBlur = blurRadius.coerceAtMost(9.dp)
-    val lensHeight = 22.dp
-    val lensAmount = 38.dp
-    val highlightAlpha = if (dark) 0.16f else 0.24f
+    val lensHeight = 24.dp
+    val lensAmount = 44.dp
+    val surfaceAlpha = if (dark) 0.74f else 0.64f
+    val surfaceColor = if (dark) Color(0xFF242424) else Color.White
+    val topHighlightAlpha = if (dark) 0.10f else 0.07f
     val material = GlassMaterialSpec.popup(effectiveBlur).copy(
         lensHeight = lensHeight,
         lensAmount = lensAmount,
-        surfaceAlpha = if (dark) 0.80f else 0.72f,
+        surfaceAlpha = surfaceAlpha,
         borderAlpha = 0f,
-        highlightAlpha = highlightAlpha,
+        highlightAlpha = 0f,
         shadowAlpha = 0f,
         innerShadowAlpha = 0f,
         depthEffect = false,
@@ -141,16 +142,13 @@ private fun Modifier.miuixCascadingPopupSurface(
             lensAmount = lensAmount,
             useVibrancy = true,
             chromaticAberration = false,
-            highlight = GlassHighlightFrame(
-                style = GlassHighlightStyle.Default,
-                alpha = highlightAlpha
-            ),
+            highlight = null,
             shadowAlpha = null,
             innerShadow = null,
             depthEffect = false
         ),
-        // NexioSchedule 款式：实色容器底（亮 #FFFFFF/0.72、暗 #242424/0.80），
-        // 边缘光与 vibrancy 由 effectFrame 提供，不再叠加径向白高光。
+        // Keep the Nexio/Miuix effect order and let the surface tint stay light enough for the
+        // stronger lens to remain visible through both primary and cascading popup layers.
         effectsOverride = {
             vibrancy()
             blur(effectiveBlur.toPx())
@@ -162,12 +160,16 @@ private fun Modifier.miuixCascadingPopupSurface(
             )
         },
         onDrawSurface = {
+            drawRect(surfaceColor.copy(alpha = surfaceAlpha))
             drawRect(
-                if (dark) {
-                    Color(0xFF242424).copy(alpha = 0.80f)
-                } else {
-                    Color(0xFFFFFFFF).copy(alpha = 0.72f)
-                }
+                brush = Brush.verticalGradient(
+                    colorStops = arrayOf(
+                        0f to Color.White.copy(alpha = topHighlightAlpha),
+                        0.22f to Color.White.copy(alpha = topHighlightAlpha * 0.34f),
+                        1f to Color.Transparent
+                    ),
+                    endY = size.height * 0.52f
+                )
             )
         }
     )
@@ -185,7 +187,7 @@ private fun rememberMiuixListPopupStyle(
     surfaceModifier = Modifier.miuixCascadingPopupSurface(
         backdrop = backdrop,
         config = config,
-        blurRadius = 14.dp
+        blurRadius = 8.dp
     ),
     backgroundColor = Color.Transparent,
     cornerRadius = cornerRadius

--- a/app/src/main/res/drawable/ic_color_colorful.xml
+++ b/app/src/main/res/drawable/ic_color_colorful.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillAlpha="0.38"
+        android:fillColor="#FF000000"
+        android:pathData="M12,4.5A4,4 0,1 1,12 12.5A4,4 0,1 1,12 4.5Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2" />
+    <path
+        android:fillAlpha="0.62"
+        android:fillColor="#FF000000"
+        android:pathData="M8.3,10.2A4.2,4.2 0,1 1,8.3 18.6A4.2,4.2 0,1 1,8.3 10.2Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2" />
+    <path
+        android:fillAlpha="0.86"
+        android:fillColor="#FF000000"
+        android:pathData="M15.7,10.2A4.2,4.2 0,1 1,15.7 18.6A4.2,4.2 0,1 1,15.7 10.2Z"
+        android:strokeColor="#FF000000"
+        android:strokeWidth="1.2" />
+</vector>

--- a/app/src/main/res/drawable/ic_color_eyedropper.xml
+++ b/app/src/main/res/drawable/ic_color_eyedropper.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M14.8,4.9L19.1,9.2M17.1,3.1L20.9,6.9C21.55,7.55 21.55,8.6 20.9,9.25L10.1,20.05H5.1V15.05L15.9,4.25C16.55,3.6 17.6,3.6 18.25,4.25M7.1,14.8L11.2,18.9"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.8" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3.7,18.7A1.6,1.6 0,1 1,3.7 21.9A1.6,1.6 0,1 1,3.7 18.7Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_color_gradient.xml
+++ b/app/src/main/res/drawable/ic_color_gradient.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillAlpha="0.14"
+        android:fillColor="#FF000000"
+        android:pathData="M7,4H17C18.66,4 20,5.34 20,7V17C20,18.66 18.66,20 17,20H7C5.34,20 4,18.66 4,17V7C4,5.34 5.34,4 7,4Z"
+        android:strokeColor="#FF000000"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.8" />
+    <path
+        android:fillAlpha="0.72"
+        android:fillColor="#FF000000"
+        android:pathData="M5,15.9L15.9,5H17C18.1,5 19,5.9 19,7V17C19,18.1 18.1,19 17,19H7C5.9,19 5,18.1 5,17Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_color_palette_ring.xml
+++ b/app/src/main/res/drawable/ic_color_palette_ring.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M18.7,16.8A8.5,8.5 0,1 1,20.1 10"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeWidth="2" />
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,9.4A2.6,2.6 0,1 1,12 14.6A2.6,2.6 0,1 1,12 9.4Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_color_solid.xml
+++ b/app/src/main/res/drawable/ic_color_solid.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillAlpha="0.16"
+        android:fillColor="#FF000000"
+        android:pathData="M7,4H17C18.66,4 20,5.34 20,7V17C20,18.66 18.66,20 17,20H7C5.34,20 4,18.66 4,17V7C4,5.34 5.34,4 7,4Z"
+        android:strokeColor="#FF000000"
+        android:strokeLineJoin="round"
+        android:strokeWidth="1.8" />
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M7.3,7.6C9.8,6.3 14.2,6.3 16.7,7.6"
+        android:strokeAlpha="0.55"
+        android:strokeColor="#FF000000"
+        android:strokeLineCap="round"
+        android:strokeWidth="1.5" />
+</vector>


### PR DESCRIPTION
## 完成

* Week 最后一行编辑控件不再覆盖 Dock；保留首末行浮标 overflow，Dock 以明确兄弟层级位于周编辑 Overlay 之上
* 单行短文案弹窗纵向压缩，壳宽、横向 padding、按钮尺寸与横向布局保持不变；多行与三按钮节奏不变
* 个性化颜色类图标更新为统一的 24dp VectorDrawable：纯色、渐变、彩色、调色环与壁纸吸色
* MIUIX Popup 液态玻璃材质调整：8dp blur、24dp / 44dp lens、更透明的明暗表面，以及从顶部向下衰减的高光；一级与级联继续共用同一材质链

## 未改变

* 课程管理首页 / 详情未动
* AI 导入未动
* Agent 未动
* Widget / WebView / TopBar 未动
* ViewSeamless 架构未动

## 验证

* `:app:compileGithubReleaseKotlin` 通过

## 实机确认

* 周视图首末行编辑浮标完整，末行不覆盖 Dock，Dock 点击及拖拽 / resize 正常
* 单行弹窗高度收紧且宽度不变，多行与三按钮弹窗节奏未回退
* 明暗壁纸下颜色图标的对齐、反色与选中态，以及壁纸吸色入口
* 浅色 / 深色下一级与级联 Popup 的透感、文字可读性、动画与 backdrop 拓扑