### PR TITLE
第二阶段体验与运行效率优化

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -234,6 +234,10 @@
             android:name=".DayAgentForegroundService"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+        <service
+            android:name=".AiImportForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
         <receiver
             android:name=".TodayCoursesWidgetProvider"
             android:label="@string/widget_today_courses_name"

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
@@ -10,29 +10,19 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.graphics.drawable.Icon
 import android.os.Build
-import android.os.PowerManager
 import android.os.IBinder
 import android.util.Log
 import androidx.core.content.ContextCompat
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 class AiImportForegroundService : Service() {
     private lateinit var notificationManager: NotificationManager
-    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var activeJob: Job? = null
     private var activeTaskId: String? = null
-    private var wakeLock: PowerManager.WakeLock? = null
 
     override fun onCreate() {
         super.onCreate()
         notificationManager = getSystemService(NotificationManager::class.java)
-        createChannels()
+        ensureChannels(this)
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -41,21 +31,19 @@ class AiImportForegroundService : Service() {
         val taskId = intent?.getStringExtra(EXTRA_TASK_ID).orEmpty()
         when (intent?.action) {
             ACTION_START -> {
-                activeJob?.cancel()
                 activeTaskId = taskId
-                val notification = runningNotification(
-                    taskId,
-                    intent.getStringExtra(EXTRA_STATUS).orEmpty()
-                )
                 startForeground(
                     RUNNING_NOTIFICATION_ID,
-                    notification
+                    runningNotification(
+                        taskId,
+                        intent.getStringExtra(EXTRA_STATUS).orEmpty()
+                    )
                 )
-                acquireWakeLock()
-                activeJob = AiImportTaskManager.launchPending(taskId, serviceScope)
-                if (activeJob == null) {
+                // The workflow itself runs on the process application scope (same as the Day
+                // Agent), so an OEM stopping this service cannot cancel the in-flight request.
+                val job = AiImportTaskManager.launchPending(this, taskId)
+                if (job == null) {
                     Log.e(TAG, "No pending AI import workflow for task=$taskId")
-                    releaseWakeLock()
                     stopForeground(STOP_FOREGROUND_REMOVE)
                     stopSelf(startId)
                 } else {
@@ -68,29 +56,11 @@ class AiImportForegroundService : Service() {
                     runningNotification(taskId, intent.getStringExtra(EXTRA_STATUS).orEmpty())
                 )
             }
-            ACTION_COMPLETE -> if (taskId == activeTaskId) {
-                val count = intent.getIntExtra(EXTRA_COURSE_COUNT, 0)
-                releaseWakeLock()
-                stopForeground(STOP_FOREGROUND_REMOVE)
-                if (NotificationScheduler.canPostNotifications(this)) {
-                    notificationManager.notify(
-                        RESULT_NOTIFICATION_ID,
-                        completedNotification(taskId, count)
-                    )
-                }
+            ACTION_COMPLETE, ACTION_FAILED -> {
+                // The result notification has already been posted directly by
+                // AiImportTaskManager; this service only clears its foreground state.
                 activeTaskId = null
-                stopSelf()
-            }
-            ACTION_FAILED -> if (taskId == activeTaskId) {
-                releaseWakeLock()
                 stopForeground(STOP_FOREGROUND_REMOVE)
-                if (NotificationScheduler.canPostNotifications(this)) {
-                    notificationManager.notify(
-                        RESULT_NOTIFICATION_ID,
-                        failedNotification(taskId, intent.getStringExtra(EXTRA_MESSAGE).orEmpty())
-                    )
-                }
-                activeTaskId = null
                 stopSelf()
             }
         }
@@ -98,9 +68,7 @@ class AiImportForegroundService : Service() {
     }
 
     override fun onDestroy() {
-        activeJob?.cancel()
-        serviceScope.cancel()
-        releaseWakeLock()
+        // Deliberately no cancellation here: the workflow intentionally outlives this service.
         super.onDestroy()
     }
 
@@ -110,7 +78,7 @@ class AiImportForegroundService : Service() {
             .setSmallIcon(R.drawable.ic_agent_thinking)
             .setContentTitle("SleepDown · AI 导入")
             .setContentText(status.ifBlank { "正在整理输入" })
-            .setContentIntent(progressPendingIntent(taskId, 8401))
+            .setContentIntent(progressPendingIntent(this, taskId, 8401))
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
@@ -118,7 +86,7 @@ class AiImportForegroundService : Service() {
             .setColor(0xFF0A84FF.toInt())
             .requestPromotedOngoing("AI导入中")
         if (Build.VERSION.SDK_INT >= 36) {
-            builder.setStyle(aiProgressStyle(stage))
+            builder.setStyle(aiProgressStyle(this, stage))
         } else {
             builder.setProgress(AI_STAGE_COUNT, stage, false)
         }
@@ -129,116 +97,10 @@ class AiImportForegroundService : Service() {
                         .getMethod("hasPromotableCharacteristics")
                         .invoke(notification) as? Boolean
                 }.getOrNull()
-                Log.d(
-                    TAG,
-                    "AI import live update built: promotable=$promotable, " +
-                        "requested=${notification.extras.getBoolean("android.requestPromotedOngoing", false)}"
-                )
+                val requested = notification.extras
+                    .getBoolean("android.requestPromotedOngoing", false)
+                Log.d(TAG, "AI import live update built: promotable=$promotable, requested=$requested")
             }
-    }
-
-    private fun completedNotification(taskId: String, courseCount: Int): Notification {
-        val builder = Notification.Builder(this, RESULT_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_agent_thinking)
-            .setContentTitle("课表解析完成 · 发现 ${courseCount} 门课程")
-            .setContentText("点击查看导入预览")
-            .setContentIntent(progressPendingIntent(taskId, 8402))
-            .setOngoing(true)
-            .setAutoCancel(false)
-            .setOnlyAlertOnce(true)
-            .setShowWhen(false)
-            .setCategory(Notification.CATEGORY_STATUS)
-            .setColor(0xFF0A84FF.toInt())
-            .requestPromotedOngoing("待查看")
-        if (Build.VERSION.SDK_INT >= 36) {
-            builder.setStyle(aiProgressStyle(AI_STAGE_COUNT))
-        } else {
-            builder.setProgress(AI_STAGE_COUNT, AI_STAGE_COUNT, false)
-        }
-        return builder.build()
-    }
-
-    private fun stageFor(status: String): Int = when {
-        "生成导入预览" in status -> 5
-        "校验" in status -> 4
-        "解析" in status -> 3
-        "已发送" in status -> 2
-        else -> 1
-    }
-
-    @Suppress("NewApi")
-    private fun aiProgressStyle(progress: Int): Notification.ProgressStyle =
-        Notification.ProgressStyle()
-            .setStyledByProgress(true)
-            .setProgressSegments(
-                listOf(
-                    Notification.ProgressStyle.Segment(AI_STAGE_COUNT)
-                        .setColor(0xFF0A84FF.toInt())
-                )
-            )
-            .setProgress(progress)
-            .setProgressTrackerIcon(Icon.createWithResource(this, R.drawable.ic_agent_thinking))
-
-    private fun failedNotification(taskId: String, message: String): Notification =
-        Notification.Builder(this, RESULT_CHANNEL_ID)
-            .setSmallIcon(R.drawable.ic_agent_thinking)
-            .setContentTitle("AI 导入未完成")
-            .setContentText(message.ifBlank { "点击查看任务详情" })
-            .setContentIntent(progressPendingIntent(taskId, 8403))
-            .setAutoCancel(true)
-            .setCategory(Notification.CATEGORY_ERROR)
-            .build()
-
-    private fun progressPendingIntent(taskId: String, requestCode: Int): PendingIntent =
-        PendingIntent.getActivity(
-            this,
-            requestCode,
-            Intent(this, AiEduImportProgressActivity::class.java)
-                .putExtra(AiImportTaskManager.EXTRA_TASK_ID, taskId)
-                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-    private fun createChannels() {
-        notificationManager.createNotificationChannels(
-            listOf(
-                NotificationChannel(
-                    RUNNING_CHANNEL_ID,
-                    "AI 导入运行状态",
-                    NotificationManager.IMPORTANCE_DEFAULT
-                ).apply { setShowBadge(false) },
-                NotificationChannel(
-                    RESULT_CHANNEL_ID,
-                    "AI 导入结果",
-                    NotificationManager.IMPORTANCE_DEFAULT
-                ).apply { setShowBadge(false) }
-            )
-        )
-    }
-
-    private fun Notification.Builder.requestPromotedOngoing(shortText: String): Notification.Builder = apply {
-        runCatching {
-            javaClass.getMethod("setRequestPromotedOngoing", java.lang.Boolean.TYPE).invoke(this, true)
-        }
-        extras.putBoolean("android.requestPromotedOngoing", true)
-        runCatching {
-            javaClass.getMethod("setShortCriticalText", CharSequence::class.java).invoke(this, shortText)
-        }.recoverCatching {
-            javaClass.getMethod("setShortCriticalText", String::class.java).invoke(this, shortText)
-        }
-        extras.putCharSequence("android.shortCriticalText", shortText)
-    }
-
-    private fun acquireWakeLock() {
-        if (wakeLock?.isHeld == true) return
-        wakeLock = getSystemService(PowerManager::class.java)
-            ?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SleepDown:ai_import")
-            ?.apply { acquire(AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS) }
-    }
-
-    private fun releaseWakeLock() {
-        wakeLock?.takeIf { it.isHeld }?.release()
-        wakeLock = null
     }
 
     companion object {
@@ -248,7 +110,6 @@ class AiImportForegroundService : Service() {
         private val ACTION_FAILED = "${BuildConfig.APPLICATION_ID}.action.AI_IMPORT_FAILED"
         private const val EXTRA_TASK_ID = "ai_import_task_id"
         private const val EXTRA_STATUS = "ai_import_status"
-        private const val EXTRA_COURSE_COUNT = "ai_import_course_count"
         private const val EXTRA_MESSAGE = "ai_import_message"
         // The old channel was created at LOW importance and Android does not allow apps to raise
         // an existing channel. A new ID lets AI import use the same promotable importance as the
@@ -258,7 +119,6 @@ class AiImportForegroundService : Service() {
         private const val RUNNING_NOTIFICATION_ID = 20260830
         private const val RESULT_NOTIFICATION_ID = 20260831
         private const val AI_STAGE_COUNT = 6
-        private const val AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS = 30L * 60L * 1_000L
         private const val TAG = "SleepDownAiImport"
 
         fun start(context: Context, taskId: String, status: String) {
@@ -276,14 +136,22 @@ class AiImportForegroundService : Service() {
         }
 
         fun complete(context: Context, taskId: String, courseCount: Int) {
+            // Post the result directly from the task side: the service may have been stopped
+            // by an OEM battery guard while the app was backgrounded, and the completion must
+            // still be shown.
+            postResultNotification(context) {
+                completedNotification(context, taskId, courseCount)
+            }
             dispatchToRunningService(
                 context,
                 serviceIntent(context, ACTION_COMPLETE, taskId)
-                    .putExtra(EXTRA_COURSE_COUNT, courseCount)
             )
         }
 
         fun fail(context: Context, taskId: String, message: String) {
+            postResultNotification(context) {
+                failedNotification(context, taskId, message)
+            }
             dispatchToRunningService(
                 context,
                 serviceIntent(context, ACTION_FAILED, taskId).putExtra(EXTRA_MESSAGE, message)
@@ -296,13 +164,126 @@ class AiImportForegroundService : Service() {
                 .cancel(RESULT_NOTIFICATION_ID)
         }
 
+        private fun postResultNotification(context: Context, build: () -> Notification) {
+            ensureChannels(context)
+            if (NotificationScheduler.canPostNotifications(context)) {
+                context.getSystemService(NotificationManager::class.java)
+                    .notify(RESULT_NOTIFICATION_ID, build())
+            }
+        }
+
+        private fun ensureChannels(context: Context) {
+            context.getSystemService(NotificationManager::class.java)
+                ?.createNotificationChannels(
+                    listOf(
+                        NotificationChannel(
+                            RUNNING_CHANNEL_ID,
+                            "AI 导入运行状态",
+                            NotificationManager.IMPORTANCE_DEFAULT
+                        ).apply { setShowBadge(false) },
+                        NotificationChannel(
+                            RESULT_CHANNEL_ID,
+                            "AI 导入结果",
+                            NotificationManager.IMPORTANCE_DEFAULT
+                        ).apply { setShowBadge(false) }
+                    )
+                )
+        }
+
+        private fun completedNotification(
+            context: Context,
+            taskId: String,
+            courseCount: Int
+        ): Notification {
+            val builder = Notification.Builder(context, RESULT_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_agent_thinking)
+                .setContentTitle("课表解析完成 · 发现 ${courseCount} 门课程")
+                .setContentText("点击查看导入预览")
+                .setContentIntent(progressPendingIntent(context, taskId, 8402))
+                .setOngoing(true)
+                .setAutoCancel(false)
+                .setOnlyAlertOnce(true)
+                .setShowWhen(false)
+                .setCategory(Notification.CATEGORY_STATUS)
+                .setColor(0xFF0A84FF.toInt())
+                .requestPromotedOngoing("待查看")
+            if (Build.VERSION.SDK_INT >= 36) {
+                builder.setStyle(aiProgressStyle(context, AI_STAGE_COUNT))
+            } else {
+                builder.setProgress(AI_STAGE_COUNT, AI_STAGE_COUNT, false)
+            }
+            return builder.build()
+        }
+
+        private fun failedNotification(
+            context: Context,
+            taskId: String,
+            message: String
+        ): Notification =
+            Notification.Builder(context, RESULT_CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_agent_thinking)
+                .setContentTitle("AI 导入未完成")
+                .setContentText(message.ifBlank { "点击查看任务详情" })
+                .setContentIntent(progressPendingIntent(context, taskId, 8403))
+                .setAutoCancel(true)
+                .setCategory(Notification.CATEGORY_ERROR)
+                .build()
+
+        private fun stageFor(status: String): Int = when {
+            "生成导入预览" in status -> 5
+            "校验" in status -> 4
+            "解析" in status -> 3
+            "已发送" in status -> 2
+            else -> 1
+        }
+
+        @Suppress("NewApi")
+        private fun aiProgressStyle(context: Context, progress: Int): Notification.ProgressStyle =
+            Notification.ProgressStyle()
+                .setStyledByProgress(true)
+                .setProgressSegments(
+                    listOf(
+                        Notification.ProgressStyle.Segment(AI_STAGE_COUNT)
+                            .setColor(0xFF0A84FF.toInt())
+                    )
+                )
+                .setProgress(progress)
+                .setProgressTrackerIcon(whiteDotProgressTrackerIcon(context))
+
+        private fun progressPendingIntent(
+            context: Context,
+            taskId: String,
+            requestCode: Int
+        ): PendingIntent =
+            PendingIntent.getActivity(
+                context,
+                requestCode,
+                Intent(context, AiEduImportProgressActivity::class.java)
+                    .putExtra(AiImportTaskManager.EXTRA_TASK_ID, taskId)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+        private fun Notification.Builder.requestPromotedOngoing(shortText: String): Notification.Builder = apply {
+            runCatching {
+                javaClass.getMethod("setRequestPromotedOngoing", java.lang.Boolean.TYPE).invoke(this, true)
+            }
+            extras.putBoolean("android.requestPromotedOngoing", true)
+            runCatching {
+                javaClass.getMethod("setShortCriticalText", CharSequence::class.java).invoke(this, shortText)
+            }.recoverCatching {
+                javaClass.getMethod("setShortCriticalText", String::class.java).invoke(this, shortText)
+            }
+            extras.putCharSequence("android.shortCriticalText", shortText)
+        }
+
         private fun dispatchToRunningService(context: Context, intent: Intent) {
             try {
                 context.startService(intent)
             } catch (error: IllegalStateException) {
                 // A vendor background-service gate must not turn a notification refresh into a
-                // cancelled provider request. The active foreground service keeps the task alive;
-                // the next meaningful state can still be observed when the UI returns.
+                // cancelled provider request. The workflow keeps running on the application
+                // scope; the next meaningful state can still be observed when the UI returns.
                 Log.w(TAG, "Unable to update AI import foreground notification", error)
             }
         }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
@@ -10,7 +10,6 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.content.ContextCompat
@@ -73,7 +72,6 @@ class AiImportForegroundService : Service() {
     }
 
     private fun runningNotification(taskId: String, status: String): Notification {
-        val stage = stageFor(status)
         val builder = Notification.Builder(this, RUNNING_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_agent_thinking)
             .setContentTitle("SleepDown · AI 导入")
@@ -85,11 +83,6 @@ class AiImportForegroundService : Service() {
             .setCategory(Notification.CATEGORY_EVENT)
             .setColor(0xFF0A84FF.toInt())
             .requestPromotedOngoing("AI导入中")
-        if (Build.VERSION.SDK_INT >= 36) {
-            builder.setStyle(aiProgressStyle(this, stage))
-        } else {
-            builder.setProgress(AI_STAGE_COUNT, stage, false)
-        }
         return builder.build()
             .also { notification ->
                 val promotable = runCatching {
@@ -118,7 +111,6 @@ class AiImportForegroundService : Service() {
         private const val RESULT_CHANNEL_ID = "ai_import_result"
         private const val RUNNING_NOTIFICATION_ID = 20260830
         private const val RESULT_NOTIFICATION_ID = 20260831
-        private const val AI_STAGE_COUNT = 6
         private const val TAG = "SleepDownAiImport"
 
         fun start(context: Context, taskId: String, status: String) {
@@ -195,7 +187,7 @@ class AiImportForegroundService : Service() {
             taskId: String,
             courseCount: Int
         ): Notification {
-            val builder = Notification.Builder(context, RESULT_CHANNEL_ID)
+            return Notification.Builder(context, RESULT_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_agent_thinking)
                 .setContentTitle("课表解析完成 · 发现 ${courseCount} 门课程")
                 .setContentText("点击查看导入预览")
@@ -207,12 +199,7 @@ class AiImportForegroundService : Service() {
                 .setCategory(Notification.CATEGORY_STATUS)
                 .setColor(0xFF0A84FF.toInt())
                 .requestPromotedOngoing("待查看")
-            if (Build.VERSION.SDK_INT >= 36) {
-                builder.setStyle(aiProgressStyle(context, AI_STAGE_COUNT))
-            } else {
-                builder.setProgress(AI_STAGE_COUNT, AI_STAGE_COUNT, false)
-            }
-            return builder.build()
+                .build()
         }
 
         private fun failedNotification(
@@ -228,27 +215,6 @@ class AiImportForegroundService : Service() {
                 .setAutoCancel(true)
                 .setCategory(Notification.CATEGORY_ERROR)
                 .build()
-
-        private fun stageFor(status: String): Int = when {
-            "生成导入预览" in status -> 5
-            "校验" in status -> 4
-            "解析" in status -> 3
-            "已发送" in status -> 2
-            else -> 1
-        }
-
-        @Suppress("NewApi")
-        private fun aiProgressStyle(context: Context, progress: Int): Notification.ProgressStyle =
-            Notification.ProgressStyle()
-                .setStyledByProgress(true)
-                .setProgressSegments(
-                    listOf(
-                        Notification.ProgressStyle.Segment(AI_STAGE_COUNT)
-                            .setColor(0xFF0A84FF.toInt())
-                    )
-                )
-                .setProgress(progress)
-                .setProgressTrackerIcon(whiteDotProgressTrackerIcon(context))
 
         private fun progressPendingIntent(
             context: Context,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
@@ -1,0 +1,186 @@
+package com.xiaomanjun.sleepdownschedule
+
+import com.xiaomanjun.sleepdownschedule.feature.importing.AiImportTaskManager
+import com.xiaomanjun.sleepdownschedule.feature.reminder.NotificationScheduler
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.content.ContextCompat
+
+class AiImportForegroundService : Service() {
+    private lateinit var notificationManager: NotificationManager
+    private var activeTaskId: String? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        notificationManager = getSystemService(NotificationManager::class.java)
+        createChannels()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val taskId = intent?.getStringExtra(EXTRA_TASK_ID).orEmpty()
+        when (intent?.action) {
+            ACTION_START -> {
+                activeTaskId = taskId
+                startForeground(
+                    RUNNING_NOTIFICATION_ID,
+                    runningNotification(taskId, intent.getStringExtra(EXTRA_STATUS).orEmpty())
+                )
+            }
+            ACTION_UPDATE -> if (taskId == activeTaskId) {
+                notificationManager.notify(
+                    RUNNING_NOTIFICATION_ID,
+                    runningNotification(taskId, intent.getStringExtra(EXTRA_STATUS).orEmpty())
+                )
+            }
+            ACTION_COMPLETE -> if (taskId == activeTaskId) {
+                val count = intent.getIntExtra(EXTRA_COURSE_COUNT, 0)
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                if (NotificationScheduler.canPostNotifications(this)) {
+                    notificationManager.notify(
+                        RESULT_NOTIFICATION_ID,
+                        completedNotification(count)
+                    )
+                }
+                stopSelf()
+            }
+            ACTION_FAILED -> if (taskId == activeTaskId) {
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                if (NotificationScheduler.canPostNotifications(this)) {
+                    notificationManager.notify(
+                        RESULT_NOTIFICATION_ID,
+                        failedNotification(taskId, intent.getStringExtra(EXTRA_MESSAGE).orEmpty())
+                    )
+                }
+                stopSelf()
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun runningNotification(taskId: String, status: String): Notification =
+        Notification.Builder(this, RUNNING_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_agent_thinking)
+            .setContentTitle("SleepDown · AI 导入")
+            .setContentText(status.ifBlank { "正在整理输入" })
+            .setContentIntent(progressPendingIntent(taskId, 8401))
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
+            .setCategory(Notification.CATEGORY_PROGRESS)
+            .setColor(0xFF0A84FF.toInt())
+            .setProgress(0, 0, true)
+            .requestPromotedOngoing("AI导入中")
+            .build()
+
+    private fun completedNotification(courseCount: Int): Notification =
+        Notification.Builder(this, RESULT_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_agent_thinking)
+            .setContentTitle("课表解析完成 · 发现 ${courseCount} 门课程")
+            .setContentText("点击查看导入预览")
+            .setContentIntent(progressPendingIntent(activeTaskId.orEmpty(), 8402))
+            .setAutoCancel(true)
+            .setCategory(Notification.CATEGORY_STATUS)
+            .setColor(0xFF0A84FF.toInt())
+            .build()
+
+    private fun failedNotification(taskId: String, message: String): Notification =
+        Notification.Builder(this, RESULT_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_agent_thinking)
+            .setContentTitle("AI 导入未完成")
+            .setContentText(message.ifBlank { "点击查看任务详情" })
+            .setContentIntent(progressPendingIntent(taskId, 8403))
+            .setAutoCancel(true)
+            .setCategory(Notification.CATEGORY_ERROR)
+            .build()
+
+    private fun progressPendingIntent(taskId: String, requestCode: Int): PendingIntent =
+        PendingIntent.getActivity(
+            this,
+            requestCode,
+            Intent(this, AiEduImportProgressActivity::class.java)
+                .putExtra(AiImportTaskManager.EXTRA_TASK_ID, taskId)
+                .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+    private fun createChannels() {
+        notificationManager.createNotificationChannels(
+            listOf(
+                NotificationChannel(
+                    RUNNING_CHANNEL_ID,
+                    "AI 导入运行状态",
+                    NotificationManager.IMPORTANCE_LOW
+                ).apply { setShowBadge(false) },
+                NotificationChannel(
+                    RESULT_CHANNEL_ID,
+                    "AI 导入结果",
+                    NotificationManager.IMPORTANCE_DEFAULT
+                ).apply { setShowBadge(false) }
+            )
+        )
+    }
+
+    private fun Notification.Builder.requestPromotedOngoing(shortText: String): Notification.Builder = apply {
+        runCatching {
+            javaClass.getMethod("setRequestPromotedOngoing", java.lang.Boolean.TYPE).invoke(this, true)
+            extras.putBoolean("android.requestPromotedOngoing", true)
+            javaClass.getMethod("setShortCriticalText", String::class.java).invoke(this, shortText)
+            extras.putString("android.shortCriticalText", shortText)
+        }
+    }
+
+    companion object {
+        private val ACTION_START = "${BuildConfig.APPLICATION_ID}.action.AI_IMPORT_START"
+        private val ACTION_UPDATE = "${BuildConfig.APPLICATION_ID}.action.AI_IMPORT_UPDATE"
+        private val ACTION_COMPLETE = "${BuildConfig.APPLICATION_ID}.action.AI_IMPORT_COMPLETE"
+        private val ACTION_FAILED = "${BuildConfig.APPLICATION_ID}.action.AI_IMPORT_FAILED"
+        private const val EXTRA_TASK_ID = "ai_import_task_id"
+        private const val EXTRA_STATUS = "ai_import_status"
+        private const val EXTRA_COURSE_COUNT = "ai_import_course_count"
+        private const val EXTRA_MESSAGE = "ai_import_message"
+        private const val RUNNING_CHANNEL_ID = "ai_import_running"
+        private const val RESULT_CHANNEL_ID = "ai_import_result"
+        private const val RUNNING_NOTIFICATION_ID = 20260830
+        private const val RESULT_NOTIFICATION_ID = 20260831
+
+        fun start(context: Context, taskId: String, status: String) {
+            ContextCompat.startForegroundService(
+                context,
+                serviceIntent(context, ACTION_START, taskId).putExtra(EXTRA_STATUS, status)
+            )
+        }
+
+        fun update(context: Context, taskId: String, status: String) {
+            context.startService(
+                serviceIntent(context, ACTION_UPDATE, taskId).putExtra(EXTRA_STATUS, status)
+            )
+        }
+
+        fun complete(context: Context, taskId: String, courseCount: Int) {
+            context.startService(
+                serviceIntent(context, ACTION_COMPLETE, taskId)
+                    .putExtra(EXTRA_COURSE_COUNT, courseCount)
+            )
+        }
+
+        fun fail(context: Context, taskId: String, message: String) {
+            context.startService(
+                serviceIntent(context, ACTION_FAILED, taskId).putExtra(EXTRA_MESSAGE, message)
+            )
+        }
+
+        private fun serviceIntent(context: Context, action: String, taskId: String): Intent =
+            Intent(context, AiImportForegroundService::class.java)
+                .setAction(action)
+                .putExtra(EXTRA_TASK_ID, taskId)
+    }
+}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
@@ -10,12 +10,15 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.PowerManager
 import android.os.IBinder
+import android.util.Log
 import androidx.core.content.ContextCompat
 
 class AiImportForegroundService : Service() {
     private lateinit var notificationManager: NotificationManager
     private var activeTaskId: String? = null
+    private var wakeLock: PowerManager.WakeLock? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -30,10 +33,16 @@ class AiImportForegroundService : Service() {
         when (intent?.action) {
             ACTION_START -> {
                 activeTaskId = taskId
+                val notification = runningNotification(
+                    taskId,
+                    intent.getStringExtra(EXTRA_STATUS).orEmpty()
+                )
                 startForeground(
                     RUNNING_NOTIFICATION_ID,
-                    runningNotification(taskId, intent.getStringExtra(EXTRA_STATUS).orEmpty())
+                    notification
                 )
+                acquireWakeLock()
+                Log.d(TAG, "AI import foreground service started task=$taskId")
             }
             ACTION_UPDATE -> if (taskId == activeTaskId) {
                 notificationManager.notify(
@@ -43,6 +52,7 @@ class AiImportForegroundService : Service() {
             }
             ACTION_COMPLETE -> if (taskId == activeTaskId) {
                 val count = intent.getIntExtra(EXTRA_COURSE_COUNT, 0)
+                releaseWakeLock()
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 if (NotificationScheduler.canPostNotifications(this)) {
                     notificationManager.notify(
@@ -53,6 +63,7 @@ class AiImportForegroundService : Service() {
                 stopSelf()
             }
             ACTION_FAILED -> if (taskId == activeTaskId) {
+                releaseWakeLock()
                 stopForeground(STOP_FOREGROUND_REMOVE)
                 if (NotificationScheduler.canPostNotifications(this)) {
                     notificationManager.notify(
@@ -66,6 +77,11 @@ class AiImportForegroundService : Service() {
         return START_NOT_STICKY
     }
 
+    override fun onDestroy() {
+        releaseWakeLock()
+        super.onDestroy()
+    }
+
     private fun runningNotification(taskId: String, status: String): Notification =
         Notification.Builder(this, RUNNING_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_agent_thinking)
@@ -75,11 +91,22 @@ class AiImportForegroundService : Service() {
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
-            .setCategory(Notification.CATEGORY_PROGRESS)
+            .setCategory(Notification.CATEGORY_EVENT)
             .setColor(0xFF0A84FF.toInt())
-            .setProgress(0, 0, true)
             .requestPromotedOngoing("AI导入中")
             .build()
+            .also { notification ->
+                val promotable = runCatching {
+                    notification.javaClass
+                        .getMethod("hasPromotableCharacteristics")
+                        .invoke(notification) as? Boolean
+                }.getOrNull()
+                Log.d(
+                    TAG,
+                    "AI import live update built: promotable=$promotable, " +
+                        "requested=${notification.extras.getBoolean("android.requestPromotedOngoing", false)}"
+                )
+            }
 
     private fun completedNotification(courseCount: Int): Notification =
         Notification.Builder(this, RESULT_CHANNEL_ID)
@@ -118,7 +145,7 @@ class AiImportForegroundService : Service() {
                 NotificationChannel(
                     RUNNING_CHANNEL_ID,
                     "AI 导入运行状态",
-                    NotificationManager.IMPORTANCE_LOW
+                    NotificationManager.IMPORTANCE_DEFAULT
                 ).apply { setShowBadge(false) },
                 NotificationChannel(
                     RESULT_CHANNEL_ID,
@@ -132,10 +159,26 @@ class AiImportForegroundService : Service() {
     private fun Notification.Builder.requestPromotedOngoing(shortText: String): Notification.Builder = apply {
         runCatching {
             javaClass.getMethod("setRequestPromotedOngoing", java.lang.Boolean.TYPE).invoke(this, true)
-            extras.putBoolean("android.requestPromotedOngoing", true)
-            javaClass.getMethod("setShortCriticalText", String::class.java).invoke(this, shortText)
-            extras.putString("android.shortCriticalText", shortText)
         }
+        extras.putBoolean("android.requestPromotedOngoing", true)
+        runCatching {
+            javaClass.getMethod("setShortCriticalText", CharSequence::class.java).invoke(this, shortText)
+        }.recoverCatching {
+            javaClass.getMethod("setShortCriticalText", String::class.java).invoke(this, shortText)
+        }
+        extras.putCharSequence("android.shortCriticalText", shortText)
+    }
+
+    private fun acquireWakeLock() {
+        if (wakeLock?.isHeld == true) return
+        wakeLock = getSystemService(PowerManager::class.java)
+            ?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SleepDown:ai_import")
+            ?.apply { acquire(AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS) }
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.takeIf { it.isHeld }?.release()
+        wakeLock = null
     }
 
     companion object {
@@ -147,10 +190,15 @@ class AiImportForegroundService : Service() {
         private const val EXTRA_STATUS = "ai_import_status"
         private const val EXTRA_COURSE_COUNT = "ai_import_course_count"
         private const val EXTRA_MESSAGE = "ai_import_message"
-        private const val RUNNING_CHANNEL_ID = "ai_import_running"
+        // The old channel was created at LOW importance and Android does not allow apps to raise
+        // an existing channel. A new ID lets AI import use the same promotable importance as the
+        // mature course live-update path.
+        private const val RUNNING_CHANNEL_ID = "ai_import_live_update"
         private const val RESULT_CHANNEL_ID = "ai_import_result"
         private const val RUNNING_NOTIFICATION_ID = 20260830
         private const val RESULT_NOTIFICATION_ID = 20260831
+        private const val AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS = 30L * 60L * 1_000L
+        private const val TAG = "SleepDownAiImport"
 
         fun start(context: Context, taskId: String, status: String) {
             ContextCompat.startForegroundService(
@@ -160,22 +208,36 @@ class AiImportForegroundService : Service() {
         }
 
         fun update(context: Context, taskId: String, status: String) {
-            context.startService(
+            dispatchToRunningService(
+                context,
                 serviceIntent(context, ACTION_UPDATE, taskId).putExtra(EXTRA_STATUS, status)
             )
         }
 
         fun complete(context: Context, taskId: String, courseCount: Int) {
-            context.startService(
+            dispatchToRunningService(
+                context,
                 serviceIntent(context, ACTION_COMPLETE, taskId)
                     .putExtra(EXTRA_COURSE_COUNT, courseCount)
             )
         }
 
         fun fail(context: Context, taskId: String, message: String) {
-            context.startService(
+            dispatchToRunningService(
+                context,
                 serviceIntent(context, ACTION_FAILED, taskId).putExtra(EXTRA_MESSAGE, message)
             )
+        }
+
+        private fun dispatchToRunningService(context: Context, intent: Intent) {
+            try {
+                context.startService(intent)
+            } catch (error: IllegalStateException) {
+                // A vendor background-service gate must not turn a notification refresh into a
+                // cancelled provider request. The active foreground service keeps the task alive;
+                // the next meaningful state can still be observed when the UI returns.
+                Log.w(TAG, "Unable to update AI import foreground notification", error)
+            }
         }
 
         private fun serviceIntent(context: Context, action: String, taskId: String): Intent =

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/AiImportForegroundService.kt
@@ -10,13 +10,22 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Icon
+import android.os.Build
 import android.os.PowerManager
 import android.os.IBinder
 import android.util.Log
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 class AiImportForegroundService : Service() {
     private lateinit var notificationManager: NotificationManager
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var activeJob: Job? = null
     private var activeTaskId: String? = null
     private var wakeLock: PowerManager.WakeLock? = null
 
@@ -32,6 +41,7 @@ class AiImportForegroundService : Service() {
         val taskId = intent?.getStringExtra(EXTRA_TASK_ID).orEmpty()
         when (intent?.action) {
             ACTION_START -> {
+                activeJob?.cancel()
                 activeTaskId = taskId
                 val notification = runningNotification(
                     taskId,
@@ -42,7 +52,15 @@ class AiImportForegroundService : Service() {
                     notification
                 )
                 acquireWakeLock()
-                Log.d(TAG, "AI import foreground service started task=$taskId")
+                activeJob = AiImportTaskManager.launchPending(taskId, serviceScope)
+                if (activeJob == null) {
+                    Log.e(TAG, "No pending AI import workflow for task=$taskId")
+                    releaseWakeLock()
+                    stopForeground(STOP_FOREGROUND_REMOVE)
+                    stopSelf(startId)
+                } else {
+                    Log.d(TAG, "AI import workflow owned by foreground service task=$taskId")
+                }
             }
             ACTION_UPDATE -> if (taskId == activeTaskId) {
                 notificationManager.notify(
@@ -57,9 +75,10 @@ class AiImportForegroundService : Service() {
                 if (NotificationScheduler.canPostNotifications(this)) {
                     notificationManager.notify(
                         RESULT_NOTIFICATION_ID,
-                        completedNotification(count)
+                        completedNotification(taskId, count)
                     )
                 }
+                activeTaskId = null
                 stopSelf()
             }
             ACTION_FAILED -> if (taskId == activeTaskId) {
@@ -71,6 +90,7 @@ class AiImportForegroundService : Service() {
                         failedNotification(taskId, intent.getStringExtra(EXTRA_MESSAGE).orEmpty())
                     )
                 }
+                activeTaskId = null
                 stopSelf()
             }
         }
@@ -78,12 +98,15 @@ class AiImportForegroundService : Service() {
     }
 
     override fun onDestroy() {
+        activeJob?.cancel()
+        serviceScope.cancel()
         releaseWakeLock()
         super.onDestroy()
     }
 
-    private fun runningNotification(taskId: String, status: String): Notification =
-        Notification.Builder(this, RUNNING_CHANNEL_ID)
+    private fun runningNotification(taskId: String, status: String): Notification {
+        val stage = stageFor(status)
+        val builder = Notification.Builder(this, RUNNING_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_agent_thinking)
             .setContentTitle("SleepDown · AI 导入")
             .setContentText(status.ifBlank { "正在整理输入" })
@@ -94,7 +117,12 @@ class AiImportForegroundService : Service() {
             .setCategory(Notification.CATEGORY_EVENT)
             .setColor(0xFF0A84FF.toInt())
             .requestPromotedOngoing("AI导入中")
-            .build()
+        if (Build.VERSION.SDK_INT >= 36) {
+            builder.setStyle(aiProgressStyle(stage))
+        } else {
+            builder.setProgress(AI_STAGE_COUNT, stage, false)
+        }
+        return builder.build()
             .also { notification ->
                 val promotable = runCatching {
                     notification.javaClass
@@ -107,17 +135,49 @@ class AiImportForegroundService : Service() {
                         "requested=${notification.extras.getBoolean("android.requestPromotedOngoing", false)}"
                 )
             }
+    }
 
-    private fun completedNotification(courseCount: Int): Notification =
-        Notification.Builder(this, RESULT_CHANNEL_ID)
+    private fun completedNotification(taskId: String, courseCount: Int): Notification {
+        val builder = Notification.Builder(this, RESULT_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_agent_thinking)
             .setContentTitle("课表解析完成 · 发现 ${courseCount} 门课程")
             .setContentText("点击查看导入预览")
-            .setContentIntent(progressPendingIntent(activeTaskId.orEmpty(), 8402))
-            .setAutoCancel(true)
+            .setContentIntent(progressPendingIntent(taskId, 8402))
+            .setOngoing(true)
+            .setAutoCancel(false)
+            .setOnlyAlertOnce(true)
+            .setShowWhen(false)
             .setCategory(Notification.CATEGORY_STATUS)
             .setColor(0xFF0A84FF.toInt())
-            .build()
+            .requestPromotedOngoing("待查看")
+        if (Build.VERSION.SDK_INT >= 36) {
+            builder.setStyle(aiProgressStyle(AI_STAGE_COUNT))
+        } else {
+            builder.setProgress(AI_STAGE_COUNT, AI_STAGE_COUNT, false)
+        }
+        return builder.build()
+    }
+
+    private fun stageFor(status: String): Int = when {
+        "生成导入预览" in status -> 5
+        "校验" in status -> 4
+        "解析" in status -> 3
+        "已发送" in status -> 2
+        else -> 1
+    }
+
+    @Suppress("NewApi")
+    private fun aiProgressStyle(progress: Int): Notification.ProgressStyle =
+        Notification.ProgressStyle()
+            .setStyledByProgress(true)
+            .setProgressSegments(
+                listOf(
+                    Notification.ProgressStyle.Segment(AI_STAGE_COUNT)
+                        .setColor(0xFF0A84FF.toInt())
+                )
+            )
+            .setProgress(progress)
+            .setProgressTrackerIcon(Icon.createWithResource(this, R.drawable.ic_agent_thinking))
 
     private fun failedNotification(taskId: String, message: String): Notification =
         Notification.Builder(this, RESULT_CHANNEL_ID)
@@ -197,6 +257,7 @@ class AiImportForegroundService : Service() {
         private const val RESULT_CHANNEL_ID = "ai_import_result"
         private const val RUNNING_NOTIFICATION_ID = 20260830
         private const val RESULT_NOTIFICATION_ID = 20260831
+        private const val AI_STAGE_COUNT = 6
         private const val AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS = 30L * 60L * 1_000L
         private const val TAG = "SleepDownAiImport"
 
@@ -227,6 +288,12 @@ class AiImportForegroundService : Service() {
                 context,
                 serviceIntent(context, ACTION_FAILED, taskId).putExtra(EXTRA_MESSAGE, message)
             )
+        }
+
+        fun clearCompletion(context: Context, taskId: String?) {
+            if (taskId.isNullOrBlank()) return
+            context.getSystemService(NotificationManager::class.java)
+                .cancel(RESULT_NOTIFICATION_ID)
         }
 
         private fun dispatchToRunningService(context: Context, intent: Intent) {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/NotificationTrackerIcon.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/NotificationTrackerIcon.kt
@@ -1,0 +1,27 @@
+package com.xiaomanjun.sleepdownschedule
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.drawable.Icon
+
+/**
+ * The Android 16 ProgressStyle default tracker renders as a paper-plane glyph; a plain
+ * white dot reads better on the blue progress bar used by our live updates.
+ */
+internal fun whiteDotProgressTrackerIcon(context: Context): Icon {
+    cachedWhiteDotIcon?.let { return it }
+    val size = 48
+    val bitmap = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888)
+    Canvas(bitmap).drawCircle(
+        size / 2f,
+        size / 2f,
+        size * 0.30f,
+        Paint(Paint.ANTI_ALIAS_FLAG).apply { color = Color.WHITE }
+    )
+    return Icon.createWithBitmap(bitmap).also { cachedWhiteDotIcon = it }
+}
+
+private var cachedWhiteDotIcon: Icon? = null

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -89,7 +89,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.Colorize
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.ui.platform.LocalView
@@ -5534,12 +5533,33 @@ private fun CourseColorModeRow(
         ) {
             if (mode == CourseCardColorMode.COLORFUL) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.Filled.ColorLens,
-                        contentDescription = "自动彩色课程卡",
-                        tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(19.dp)
-                    )
+                    // A four-color dot cluster reads instantly as "colorful"; a themed glyph
+                    // cannot express the multi-palette idea on its own.
+                    Canvas(
+                        Modifier
+                            .size(19.dp)
+                            .semantics { contentDescription = "自动彩色课程卡" }
+                    ) {
+                        val dotRadius = size.minDimension * 0.165f
+                        val gap = size.minDimension * 0.235f
+                        val centerX = size.width / 2f
+                        val centerY = size.height / 2f
+                        val dotColors = listOf(
+                            ComposeColor(0xFFFF5A52),
+                            ComposeColor(0xFFFFB300),
+                            ComposeColor(0xFF30C851),
+                            ComposeColor(0xFF0A84FF)
+                        )
+                        val dotCenters = listOf(
+                            Offset(centerX - gap, centerY - gap),
+                            Offset(centerX + gap, centerY - gap),
+                            Offset(centerX - gap, centerY + gap),
+                            Offset(centerX + gap, centerY + gap)
+                        )
+                        dotCenters.forEachIndexed { index, center ->
+                            drawCircle(color = dotColors[index], radius = dotRadius, center = center)
+                        }
+                    }
                 }
             } else {
                 Box(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -89,6 +89,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ColorLens
 import androidx.compose.material.icons.filled.Colorize
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.ui.platform.LocalView
@@ -5506,10 +5507,103 @@ private fun CourseColorModeRow(
     selectedMode: CourseCardColorMode,
     presets: List<List<Long>>,
     selectedPreset: (List<Long>) -> Boolean,
+    customSelected: Boolean,
+    backdrop: Backdrop?,
     onPresetSelected: (List<Long>) -> Unit,
     onOpenPalette: () -> Unit
 ) {
     val foreground = LocalContentColor.current
+    @Composable
+    fun PresetButton(colors: List<Long>) {
+        val selected = selectedMode == mode && selectedPreset(colors)
+        val previewColors = when (mode) {
+            CourseCardColorMode.SOLID -> colors.map { ComposeColor(it.toInt()) }
+            CourseCardColorMode.GRADIENT -> tonalPreviewColors(colors.first())
+            CourseCardColorMode.COLORFUL -> colors.map { vividPreviewColor(it) }
+        }
+        Surface(
+            modifier = Modifier.size(32.dp),
+            shape = RoundedCornerShape(50),
+            color = if (mode == CourseCardColorMode.COLORFUL) {
+                ComposeColor.White.copy(alpha = 0.88f)
+            } else {
+                ComposeColor.Transparent
+            },
+            border = if (selected) BorderStroke(2.dp, MaterialTheme.colorScheme.primary) else null,
+            onClick = { onPresetSelected(colors) }
+        ) {
+            if (mode == CourseCardColorMode.COLORFUL) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Filled.ColorLens,
+                        contentDescription = "自动彩色课程卡",
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(19.dp)
+                    )
+                }
+            } else {
+                Box(
+                    Modifier.background(
+                        if (previewColors.size == 1) {
+                            Brush.linearGradient(listOf(previewColors.first(), previewColors.first()))
+                        } else {
+                            Brush.linearGradient(previewColors)
+                        }
+                    )
+                )
+            }
+        }
+    }
+
+    @Composable
+    fun PaletteButton() {
+        val buttonColor = if (customSelected) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            ComposeColor.White.copy(alpha = 0.90f)
+        }
+        val iconColor = if (customSelected) ComposeColor.White else ComposeColor(0xFF1A1A1A)
+        if (backdrop != null) {
+            LiquidButton(
+                onClick = onOpenPalette,
+                backdrop = backdrop,
+                modifier = Modifier.size(32.dp),
+                height = 32.dp,
+                contentPadding = PaddingValues(0.dp),
+                surfaceColor = buttonColor,
+                blurRadius = 8.dp,
+                lensHeight = 18.dp,
+                lensAmount = 22.dp,
+                chromaticAberration = false
+            ) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Filled.Palette,
+                        contentDescription = "自定义课程卡颜色",
+                        tint = iconColor,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        } else {
+            Surface(
+                modifier = Modifier.size(32.dp),
+                shape = RoundedCornerShape(50),
+                color = buttonColor,
+                onClick = onOpenPalette
+            ) {
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = Icons.Filled.Palette,
+                        contentDescription = "自定义课程卡颜色",
+                        tint = iconColor,
+                        modifier = Modifier.size(18.dp)
+                    )
+                }
+            }
+        }
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -5526,75 +5620,26 @@ private fun CourseColorModeRow(
         )
         Row(
             modifier = Modifier.weight(1f),
-            horizontalArrangement = if (mode == CourseCardColorMode.COLORFUL) {
-                Arrangement.spacedBy(18.dp, Alignment.CenterHorizontally)
-            } else {
-                Arrangement.SpaceEvenly
-            },
+            horizontalArrangement = Arrangement.SpaceEvenly,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            presets.forEach { colors ->
-                val selected = selectedMode == mode && selectedPreset(colors)
-                val previewColors = when (mode) {
-                    CourseCardColorMode.SOLID -> colors.map { ComposeColor(it.toInt()) }
-                    CourseCardColorMode.GRADIENT -> tonalPreviewColors(colors.first())
-                    CourseCardColorMode.COLORFUL -> colors.map { vividPreviewColor(it) }
+            if (mode == CourseCardColorMode.COLORFUL) {
+                repeat(5) { index ->
+                    Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                        when (index) {
+                            1 -> PresetButton(presets.first())
+                            3 -> PaletteButton()
+                        }
+                    }
                 }
-                val shape = RoundedCornerShape(50)
-                Surface(
-                    modifier = Modifier.size(32.dp),
-                    shape = shape,
-                    color = ComposeColor.Transparent,
-                    border = if (selected) {
-                        BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
-                    } else {
-                        null
-                    },
-                    onClick = { onPresetSelected(colors) }
-                ) {
-                    Box(
-                        Modifier.background(
-                            when {
-                                previewColors.size == 1 -> Brush.linearGradient(
-                                    listOf(
-                                        previewColors.first(),
-                                        previewColors.first()
-                                    )
-                                )
-                                mode == CourseCardColorMode.COLORFUL -> Brush.sweepGradient(
-                                    previewColors
-                                )
-                                else -> Brush.linearGradient(
-                                    previewColors
-                                )
-                            }
-                        )
-                    )
+            } else {
+                presets.forEach { colors ->
+                    Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                        PresetButton(colors)
+                    }
                 }
-            }
-            Surface(
-                modifier = Modifier.size(32.dp),
-                shape = RoundedCornerShape(50),
-                color = ComposeColor.Transparent,
-                border = null,
-                onClick = onOpenPalette
-            ) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(
-                            Brush.sweepGradient(
-                                AutomaticColorfulCoursePreview.map { vividPreviewColor(it) }
-                            )
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Palette,
-                        contentDescription = "自定义课程卡颜色",
-                        tint = if (foreground.luminance() > 0.5f) ComposeColor.White else ComposeColor.Black,
-                        modifier = Modifier.size(19.dp)
-                    )
+                Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                    PaletteButton()
                 }
             }
         }
@@ -6201,6 +6246,9 @@ fun PersonalizePanel(
                     selectedMode = state.config.courseCardColorMode,
                     presets = SolidCourseColorPresets.map { listOf(it) },
                     selectedPreset = { it.firstOrNull() == state.config.cardColorArgb },
+                    customSelected = state.config.courseCardColorMode == CourseCardColorMode.SOLID &&
+                        SolidCourseColorPresets.none { it == state.config.cardColorArgb },
+                    backdrop = backdrop,
                     onPresetSelected = { colors ->
                         onUpdateConfig(
                             PersonalizeCardColorChange,
@@ -6218,6 +6266,9 @@ fun PersonalizePanel(
                     selectedMode = state.config.courseCardColorMode,
                     presets = GradientCourseColorPresets.map { listOf(it) },
                     selectedPreset = { it.firstOrNull() == state.config.cardColorArgb },
+                    customSelected = state.config.courseCardColorMode == CourseCardColorMode.GRADIENT &&
+                        GradientCourseColorPresets.none { it == state.config.cardColorArgb },
+                    backdrop = backdrop,
                     onPresetSelected = { colors ->
                         onUpdateConfig(
                             PersonalizeCardColorChange,
@@ -6235,6 +6286,9 @@ fun PersonalizePanel(
                     selectedMode = state.config.courseCardColorMode,
                     presets = listOf(AutomaticColorfulCoursePreview),
                     selectedPreset = { state.config.courseCardPalette.isBlank() },
+                    customSelected = state.config.courseCardColorMode == CourseCardColorMode.COLORFUL &&
+                        state.config.courseCardPalette.isNotBlank(),
+                    backdrop = backdrop,
                     onPresetSelected = {
                         onUpdateConfig(
                             PersonalizeCardColorChange,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -4568,9 +4568,8 @@ internal fun AppTopBar(
                 .height(66.dp)
                 .graphicsLayer { clip = false }
         ) {
-            // Material's app-bar layout owns the stable title geometry. Keep the animated liquid
-            // controls in a later sibling so their press/morph envelope is not clipped to that
-            // layout's bounds.
+            // Keep Material's bar shell, but render both the title and animated liquid controls as
+            // siblings so neither is clipped by TopAppBar's internal single-line title layout.
             TopAppBar(
                 modifier = Modifier.fillMaxSize(),
                 colors = TopAppBarDefaults.topAppBarColors(
@@ -4580,18 +4579,25 @@ internal fun AppTopBar(
                     actionIconContentColor = homeTextColor,
                     navigationIconContentColor = homeTextColor
                 ),
-                title = {
-                    HomeDateTitle(
-                        state = state,
-                        displayDate = homeDisplayDate,
-                        displayWeek = homeDisplayWeek,
-                        beforeScheduleTerm = beforeScheduleTerm,
-                        afterScheduleTerm = afterScheduleTerm,
-                        showReturnToCurrentWeekHint = homeShowingAnotherWeek,
-                        onReturnCurrent = onReturnHomeToCurrentWeek
-                    )
-                }
+                title = {}
             )
+            Box(
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .fillMaxWidth()
+                    .padding(start = 16.dp, end = 120.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                HomeDateTitle(
+                    state = state,
+                    displayDate = homeDisplayDate,
+                    displayWeek = homeDisplayWeek,
+                    beforeScheduleTerm = beforeScheduleTerm,
+                    afterScheduleTerm = afterScheduleTerm,
+                    showReturnToCurrentWeekHint = homeShowingAnotherWeek,
+                    onReturnCurrent = onReturnHomeToCurrentWeek
+                )
+            }
             Row(
                 modifier = Modifier
                     .align(Alignment.CenterEnd)

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/analytics/InstallationAnalytics.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/analytics/InstallationAnalytics.kt
@@ -22,7 +22,8 @@ internal class InstallationAnalytics(context: Context) {
             versionCode = BuildConfig.VERSION_CODE.toLong(),
             versionName = BuildConfig.VERSION_NAME,
             androidApi = Build.VERSION.SDK_INT,
-            deviceModel = Build.MODEL.orEmpty().trim().take(128)
+            deviceModel = Build.MODEL.orEmpty().trim().take(128),
+            deviceBrand = Build.MANUFACTURER.orEmpty().trim().take(64)
         )
         if (!prefs.getBoolean(KeyRegistered, false)) {
             val registered = runCatching {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/remoteconfig/RemoteConfigModels.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/remoteconfig/RemoteConfigModels.kt
@@ -101,7 +101,8 @@ data class InstallationPayload(
     val versionCode: Long,
     val versionName: String,
     val androidApi: Int,
-    val deviceModel: String
+    val deviceModel: String,
+    val deviceBrand: String = ""
 )
 
 data class RemoteExperienceState(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDesignTokens.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDesignTokens.kt
@@ -63,12 +63,11 @@ object SleepDownDesignTokens {
         // Short-copy alerts may tighten this gap without changing their action geometry or the
         // action-to-edge spacing.
         val AlertSingleLineActionSpacing = 18.dp
-        // Single-row-action alerts are tightened only through their copy band. Their action row
-        // keeps the accepted height, spacing and edge inset.
+        // Single-row-action alerts tighten the copy band regardless of message line count. Their
+        // action row keeps the accepted height, spacing and edge inset.
         val CompactAlertTopInset = 28.dp
         val CompactTitleContentSpacing = 11.dp
-        val CompactMessageActionSpacing = 27.dp
-        val CompactSingleLineActionSpacing = 16.dp
+        val CompactActionSpacing = 16.dp
         // A title plus a two-line message keeps its measured shell and action row unchanged; only
         // the copy is optically lifted so the extra line does not make the upper half look heavy.
         val ThreeLineAlertTextLift = 3.dp

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDialog.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/designsystem/SleepDownDialog.kt
@@ -370,15 +370,11 @@ private fun LiquidAlertContent(
         }
         Spacer(
             Modifier.height(
-                if (messageSingleLine) {
-                    if (compact) {
-                        SleepDownDesignTokens.CenteredDialog.CompactSingleLineActionSpacing
-                    } else {
-                        SleepDownDesignTokens.CenteredDialog.AlertSingleLineActionSpacing
-                    }
+                if (compact) {
+                    SleepDownDesignTokens.CenteredDialog.CompactActionSpacing
                 } else {
-                    if (compact) {
-                        SleepDownDesignTokens.CenteredDialog.CompactMessageActionSpacing
+                    if (messageSingleLine) {
+                        SleepDownDesignTokens.CenteredDialog.AlertSingleLineActionSpacing
                     } else {
                         SleepDownDesignTokens.CenteredDialog.MessageActionSpacing
                     }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/AgentOpenAiResponses.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/AgentOpenAiResponses.kt
@@ -23,11 +23,21 @@ import kotlinx.serialization.json.put
 
 private val AgentResponsesJson = Json { ignoreUnknownKeys = true; isLenient = true }
 
+private fun toolDecisionReasoningEffort(profile: AiProviderProfile): AiReasoningEffort {
+    val supported = AiProviderPresets.reasoningEfforts(profile)
+    return when {
+        AiReasoningEffort.MINIMAL in supported -> AiReasoningEffort.MINIMAL
+        AiReasoningEffort.LOW in supported -> AiReasoningEffort.LOW
+        else -> profile.reasoningEffort
+    }
+}
+
 internal data class AgentResponsesTurn(
     val outputItems: List<JsonObject>,
     val calls: List<AgentToolCall>,
     val content: String,
-    val unparsedToolCallCount: Int
+    val unparsedToolCallCount: Int,
+    val usage: AgentTokenUsage
 )
 
 /**
@@ -45,7 +55,8 @@ internal class OpenAiResponsesAgentRunner {
         onStatus: (AgentRunStatus) -> Unit,
         onDelta: (String) -> Unit,
         onStreamReset: () -> Unit,
-        executeTool: (AgentToolCall) -> AgentToolResult
+        executeTool: (AgentToolCall) -> AgentToolResult,
+        telemetry: DayAgentTurnTelemetry
     ): String {
         val instructions = chatMessages
             .filter { it["role"]?.jsonPrimitive?.contentOrNull == "system" }
@@ -56,9 +67,12 @@ internal class OpenAiResponsesAgentRunner {
             .map(::toResponsesInputMessage)
             .toMutableList()
         val completedOneShotTools = mutableSetOf<AgentToolName>()
+        val evidenceKeys = mutableSetOf<String>()
+        val decisionEffort = toolDecisionReasoningEffort(settings.profile)
 
-        repeat(6) {
+        toolRounds@ for (round in 0 until MaxAgentToolRounds) {
             onStatus(AgentRunStatus(AgentRunStatusIcon.THINKING, "正在思考"))
+            telemetry.requestStarted()
             val decision = parseAgentResponsesTurn(
                 post(
                     settings,
@@ -70,10 +84,13 @@ internal class OpenAiResponsesAgentRunner {
                         stream = false,
                         includeTools = true,
                         includeMemoryTool = includeMemoryTool,
-                        excludedTools = completedOneShotTools
+                        excludedTools = completedOneShotTools,
+                        reasoningEffort = decisionEffort
                     )
                 )
             )
+            telemetry.recordUsage(decision.usage)
+            telemetry.recordDecisionRound(decision.calls.size)
             if (decision.unparsedToolCallCount > 0) {
                 throw IllegalStateException(
                     "模型返回了 ${decision.unparsedToolCallCount} 个无法识别的工具调用，请重试"
@@ -98,13 +115,14 @@ internal class OpenAiResponsesAgentRunner {
                     input = input,
                     onStatus = onStatus,
                     onDelta = onDelta,
-                    onStreamReset = onStreamReset
+                    onStreamReset = onStreamReset,
+                    telemetry = telemetry
                 )
             }
 
             // Stateless Responses continuation requires every output item, not just visible text.
             input += decision.outputItems
-            decision.calls.forEach { call ->
+            val results = decision.calls.map { call ->
                 onStatus(call.name.runStatus())
                 val result = executeTool(call)
                 input += buildJsonObject {
@@ -113,7 +131,13 @@ internal class OpenAiResponsesAgentRunner {
                     put("output", result.content)
                 }
                 if (call.name.isOneShotPerTurn) completedOneShotTools += call.name
+                result
             }
+            telemetry.recordToolResults(results)
+            val addedEvidence = decision.calls
+                .map { call -> evidenceKeys.add(call.cacheKey()) }
+                .any { it }
+            if (!addedEvidence) break@toolRounds
         }
 
         return streamFinal(
@@ -122,7 +146,8 @@ internal class OpenAiResponsesAgentRunner {
             input = input,
             onStatus = onStatus,
             onDelta = onDelta,
-            onStreamReset = onStreamReset
+            onStreamReset = onStreamReset,
+            telemetry = telemetry
         )
     }
 
@@ -132,9 +157,11 @@ internal class OpenAiResponsesAgentRunner {
         input: List<JsonObject>,
         onStatus: (AgentRunStatus) -> Unit,
         onDelta: (String) -> Unit,
-        onStreamReset: () -> Unit
+        onStreamReset: () -> Unit,
+        telemetry: DayAgentTurnTelemetry
     ): String {
         onStatus(AgentRunStatus(AgentRunStatusIcon.THINKING, "整理结果"))
+        telemetry.finalAnswerStarted()
         val finalInstructions = instructions + "\n\n" + DayAgentPrompts.FinalAnswerStage
         val body = responsesBody(
             settings = settings,
@@ -143,11 +170,13 @@ internal class OpenAiResponsesAgentRunner {
             stream = true,
             includeTools = false,
             includeMemoryTool = false,
-            excludedTools = emptySet()
+            excludedTools = emptySet(),
+            reasoningEffort = settings.profile.reasoningEffort
         )
         return try {
+            telemetry.requestStarted()
             val gate = AgentFinalOutputGate(onDelta)
-            gate.finish(stream(settings, body, gate::accept))
+            gate.finish(stream(settings, body, gate::accept, telemetry::recordUsage))
         } catch (error: Throwable) {
             if (error !is MissingResponsesBodyException &&
                 error !is MissingAgentBodyException &&
@@ -164,9 +193,13 @@ internal class OpenAiResponsesAgentRunner {
                 stream = false,
                 includeTools = false,
                 includeMemoryTool = false,
-                excludedTools = emptySet()
+                excludedTools = emptySet(),
+                reasoningEffort = settings.profile.reasoningEffort
             )
-            val content = parseAgentResponsesTurn(post(settings, retry)).content
+            telemetry.requestStarted()
+            val retryTurn = parseAgentResponsesTurn(post(settings, retry))
+            telemetry.recordUsage(retryTurn.usage)
+            val content = retryTurn.content
                 .takeIf(String::isNotBlank)
                 ?: throw MissingResponsesBodyException()
             if (containsLeakedAgentFunctionProtocol(content)) {
@@ -184,7 +217,8 @@ internal class OpenAiResponsesAgentRunner {
         stream: Boolean,
         includeTools: Boolean,
         includeMemoryTool: Boolean,
-        excludedTools: Set<AgentToolName>
+        excludedTools: Set<AgentToolName>,
+        reasoningEffort: AiReasoningEffort
     ): JsonObject = buildJsonObject {
         put("model", settings.profile.defaultModel)
         put("store", false)
@@ -192,7 +226,7 @@ internal class OpenAiResponsesAgentRunner {
         put("instructions", instructions)
         put("input", JsonArray(input))
         put("reasoning", buildJsonObject {
-            put("effort", settings.profile.reasoningEffort.apiValue)
+            put("effort", reasoningEffort.apiValue)
             if (
                 settings.profile.id == AiProviderPresets.openAI.id &&
                 isOfficialOpenAIBaseUrl(settings.profile.baseUrl)
@@ -221,7 +255,8 @@ internal class OpenAiResponsesAgentRunner {
     private fun stream(
         settings: AiImportSettings,
         body: JsonObject,
-        onDelta: (String) -> Unit
+        onDelta: (String) -> Unit,
+        onUsage: (AgentTokenUsage) -> Unit
     ): String {
         val connection = open(settings, body)
         val code = connection.responseCode
@@ -233,7 +268,9 @@ internal class OpenAiResponsesAgentRunner {
         if (!connection.contentType.orEmpty().contains("text/event-stream", ignoreCase = true)) {
             val response = connection.inputStream.bufferedReader().use { it.readText() }
             connection.disconnect()
-            val content = parseAgentResponsesTurn(response).content
+            val turn = parseAgentResponsesTurn(response)
+            onUsage(turn.usage)
+            val content = turn.content
                 .takeIf(String::isNotBlank)
                 ?: throw MissingResponsesBodyException()
             onDelta(content)
@@ -249,6 +286,8 @@ internal class OpenAiResponsesAgentRunner {
                 val event = runCatching {
                     AgentResponsesJson.parseToJsonElement(data).jsonObject
                 }.getOrNull() ?: return@forEach
+                val usage = agentTokenUsage(event)
+                if (!usage.isEmpty) onUsage(usage)
                 when (event["type"]?.jsonPrimitive?.contentOrNull) {
                     "response.output_text.delta" -> {
                         val delta = event["delta"]?.jsonPrimitive?.contentOrNull.orEmpty()
@@ -370,7 +409,8 @@ internal fun parseAgentResponsesTurn(response: String): AgentResponsesTurn {
         outputItems = outputItems,
         calls = calls,
         content = content,
-        unparsedToolCallCount = functionItems.size - calls.size
+        unparsedToolCallCount = functionItems.size - calls.size,
+        usage = agentTokenUsage(root)
     )
 }
 

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/AgentTools.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/AgentTools.kt
@@ -511,9 +511,10 @@ private fun agentWeekResult(facts: DayAgentFacts): String = buildString {
 
 private fun agentSemesterResult(facts: DayAgentFacts): String = buildString {
     appendLine("学期状态=${facts.termState.name}（${facts.termStatus}）")
+    appendLine("课程行=id|名称|星期|节次|周次；可选字段 p=单双周（默认 ALL）、l=地点、t=教师、x=自定义时间")
     append(
         facts.semesterCourses.distinctBy { it.id }
-            .joinToString("\n", transform = ::agentCourseLine)
+            .joinToString("\n", transform = ::agentCompactCourseLine)
             .ifBlank { "本学期无课程" }
     )
 }
@@ -562,3 +563,39 @@ private fun agentCourseLine(course: CourseEntity): String =
         course.customTimeRangeOrNull()?.let { (start, end) ->
             "；自定义时间=${start}-${end}（优先于节次默认时间）"
         }.orEmpty()
+
+private fun agentCompactCourseLine(course: CourseEntity): String = buildList {
+    add(course.id.toString())
+    add(course.name.toAgentCompactField())
+    add(course.weekday.toString())
+    add(course.periods.toAgentRanges())
+    add(course.weeks.toAgentRanges())
+    if (course.weekParity != WeekParity.ALL) add("p=${course.weekParity}")
+    course.location?.takeIf(String::isNotBlank)?.let { add("l=${it.toAgentCompactField()}") }
+    course.teacher?.takeIf(String::isNotBlank)?.let { add("t=${it.toAgentCompactField()}") }
+    course.customTimeRangeOrNull()?.let { (start, end) -> add("x=$start-$end") }
+}.joinToString("|")
+
+private fun String.toAgentCompactField(): String = trim()
+    .replace('|', '／')
+    .replace('\r', ' ')
+    .replace('\n', ' ')
+
+private fun List<Int>.toAgentRanges(): String {
+    val values = distinct().sorted()
+    if (values.isEmpty()) return "-"
+    val ranges = mutableListOf<String>()
+    var start = values.first()
+    var end = start
+    values.drop(1).forEach { value ->
+        if (value == end + 1) {
+            end = value
+        } else {
+            ranges += if (start == end) "$start" else "$start-$end"
+            start = value
+            end = value
+        }
+    }
+    ranges += if (start == end) "$start" else "$start-$end"
+    return ranges.joinToString(",")
+}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/DayAgentChatTransport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/DayAgentChatTransport.kt
@@ -47,7 +47,12 @@ internal class DayAgentChatTransport {
         }
     }
 
-    fun stream(settings: AiImportSettings, body: String, onDelta: (String) -> Unit): String {
+    fun stream(
+        settings: AiImportSettings,
+        body: String,
+        onDelta: (String) -> Unit,
+        onUsage: (AgentTokenUsage) -> Unit
+    ): String {
         val connection = openConnection(settings, body)
         return try {
             val code = connection.responseCode
@@ -60,9 +65,9 @@ internal class DayAgentChatTransport {
                 throw IllegalStateException(formatAiRequestError(code, error, settings.profile.id))
             }
             if (!connection.contentType.orEmpty().contains("text/event-stream", ignoreCase = true)) {
-                val content = parseFullChatContent(
-                    connection.inputStream.bufferedReader().use { it.readText() }
-                )
+                val response = connection.inputStream.bufferedReader().use { it.readText() }
+                onUsage(parseAgentTokenUsage(response))
+                val content = parseFullChatContent(response)
                 onDelta(content)
                 content
             } else {
@@ -73,9 +78,13 @@ internal class DayAgentChatTransport {
                         if (!line.startsWith("data:")) return@forEach
                         val data = line.removePrefix("data:").trim()
                         if (data == "[DONE]" || data.isBlank()) return@forEach
+                        val event = runCatching {
+                            AgentChatJson.parseToJsonElement(data).jsonObject
+                        }.getOrNull() ?: return@forEach
+                        val usage = agentTokenUsage(event)
+                        if (!usage.isEmpty) onUsage(usage)
                         val content = runCatching {
-                            val choice = AgentChatJson.parseToJsonElement(data)
-                                .jsonObject["choices"]
+                            val choice = event["choices"]
                                 ?.jsonArray
                                 ?.firstOrNull()
                                 ?.jsonObject

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/DayAgentPrompts.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/DayAgentPrompts.kt
@@ -37,7 +37,7 @@ courseId 只能使用本轮工具返回的真实 ID；交换课程必须输出�
 若只是回答，不输出机器标记。凡提出可确认的实际操作，必须把完整计划放在正文末尾唯一的 <agent_actions>[合法 JSON 数组]</agent_actions> 中；不用 Markdown 代码围栏、注释或尾随逗号，不得声称已经执行。"""
 
     const val ToolDecisionStage = """[工具决策阶段]
-只可调用请求体 tools 中真实提供的函数。先一次判断完成任务所需的全部事实，把当前即可确定且相互独立的读取在同一响应中并行发出；不要逐个试探，也不要重复同名同参数调用。一次性快照工具调用后会从后续列表移除，但结果仍在上下文中。SEARCH_COURSES 仅在需要不同关键词时重复。
+只可调用请求体 tools 中真实提供的函数。先一次判断完成任务所需的全部事实，把当前即可确定且相互独立的读取在同一响应中并行发出；不要逐个试探，也不要重复同名同参数调用。一次性快照工具调用后会从后续列表移除，但结果仍在上下文中。SEARCH_COURSES 仅在需要不同关键词时重复。通常在三轮内收敛；上一轮没有带来新事实、事实版本、新查询或新工具结果时，立即结束工具阶段。
 工具选择：当前状态读 GET_CURRENT_OVERVIEW；明确课程读 SEARCH_COURSES；周内空档/冲突读 GET_WEEK_SCHEDULE；总览或跨周修改读 GET_SEMESTER_SCHEDULE；节次/作息读 GET_PERIODS；设置读 GET_SETTINGS。结构调整若可能改变课程实际时间，同时读取 GET_PERIODS、GET_SETTINGS 和所需课程范围。
 调用工具时可用一句不超过 35 个汉字的说明，并在同一响应发出标准 tool_calls/function_call；不要展示推理。事实已充分时只输出 FINAL_ANSWER_READY。ADD_COURSE、UPDATE_COURSE、DELETE_COURSE、OPEN_SETTINGS、SET_SETTING、SET_PERIOD_SETTINGS 是最终 JSON 的 type，不是函数；禁止放入 tool_calls、DSML 或自造协议。本阶段不要写最终正文。"""
 

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/DayAgentService.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/DayAgentService.kt
@@ -11,6 +11,8 @@ import androidx.core.content.edit
 import android.content.pm.PackageManager
 import android.location.Location
 import android.location.LocationManager
+import android.os.SystemClock
+import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
@@ -40,8 +42,9 @@ import java.time.ZoneId
 import java.util.UUID
 
 private val DayAgentJson = Json { ignoreUnknownKeys = true; isLenient = true }
-private const val MaxAgentToolRounds = 6
+internal const val MaxAgentToolRounds = 3
 private const val DayAgentWeatherCacheMillis = 30 * 60 * 1000L
+private const val DayAgentMetricsTag = "DayAgentMetrics"
 
 internal fun isDayAgentWeatherCacheFresh(fetchedAt: Long, now: Long): Boolean {
     if (fetchedAt <= 0L) return false
@@ -56,8 +59,97 @@ internal data class AgentToolDecision(
     val finishReason: String,
     val unparsedToolCallCount: Int,
     val webSearchUsed: Boolean,
-    val providerWebSearchRequested: Boolean
+    val providerWebSearchRequested: Boolean,
+    val usage: AgentTokenUsage
 )
+
+internal data class AgentTokenUsage(
+    val inputTokens: Long = 0,
+    val outputTokens: Long = 0,
+    val cachedInputTokens: Long = 0,
+    val reasoningTokens: Long = 0
+) {
+    val isEmpty: Boolean
+        get() = inputTokens == 0L && outputTokens == 0L &&
+            cachedInputTokens == 0L && reasoningTokens == 0L
+}
+
+internal class DayAgentTurnTelemetry(private val providerId: String) {
+    private var totalRequests = 0
+    private var decisionRounds = 0
+    private val callsPerRound = mutableListOf<Int>()
+    private var toolResultCharacters = 0
+    private var inputTokens = 0L
+    private var outputTokens = 0L
+    private var cachedInputTokens = 0L
+    private var reasoningTokens = 0L
+    private var finalStartedAt = 0L
+
+    fun requestStarted() {
+        totalRequests += 1
+    }
+
+    fun recordDecisionRound(toolCalls: Int) {
+        decisionRounds += 1
+        callsPerRound += toolCalls
+    }
+
+    fun recordToolResults(results: List<AgentToolResult>) {
+        toolResultCharacters += results.sumOf { it.content.length }
+    }
+
+    fun recordUsage(usage: AgentTokenUsage) {
+        inputTokens += usage.inputTokens
+        outputTokens += usage.outputTokens
+        cachedInputTokens += usage.cachedInputTokens
+        reasoningTokens += usage.reasoningTokens
+    }
+
+    fun finalAnswerStarted() {
+        if (finalStartedAt == 0L) finalStartedAt = SystemClock.elapsedRealtime()
+    }
+
+    fun logSummary() {
+        val finalLatency = finalStartedAt.takeIf { it > 0L }
+            ?.let { SystemClock.elapsedRealtime() - it }
+            ?: 0L
+        Log.i(
+            DayAgentMetricsTag,
+            "provider=$providerId decisionRounds=$decisionRounds callsPerRound=${callsPerRound.joinToString(",")} " +
+                "requests=$totalRequests toolResultChars=$toolResultCharacters inputTokens=$inputTokens " +
+                "outputTokens=$outputTokens cachedInputTokens=$cachedInputTokens " +
+                "reasoningTokens=$reasoningTokens finalLatencyMs=$finalLatency"
+        )
+    }
+}
+
+internal fun parseAgentTokenUsage(response: String): AgentTokenUsage = runCatching {
+    agentTokenUsage(DayAgentJson.parseToJsonElement(response).jsonObject)
+}.getOrDefault(AgentTokenUsage())
+
+internal fun agentTokenUsage(root: JsonObject): AgentTokenUsage {
+    val responseRoot = (root["response"] as? JsonObject) ?: root
+    val usage = responseRoot["usage"] as? JsonObject ?: return AgentTokenUsage()
+    fun token(vararg keys: String): Long = keys.asSequence()
+        .mapNotNull { usage[it]?.jsonPrimitive?.contentOrNull?.toLongOrNull() }
+        .firstOrNull() ?: 0L
+    fun detailToken(detailsKeys: List<String>, tokenKey: String): Long = detailsKeys.asSequence()
+        .mapNotNull { usage[it] as? JsonObject }
+        .mapNotNull { it[tokenKey]?.jsonPrimitive?.contentOrNull?.toLongOrNull() }
+        .firstOrNull() ?: 0L
+    return AgentTokenUsage(
+        inputTokens = token("input_tokens", "prompt_tokens"),
+        outputTokens = token("output_tokens", "completion_tokens"),
+        cachedInputTokens = detailToken(
+            listOf("input_tokens_details", "prompt_tokens_details"),
+            "cached_tokens"
+        ),
+        reasoningTokens = detailToken(
+            listOf("output_tokens_details", "completion_tokens_details"),
+            "reasoning_tokens"
+        )
+    )
+}
 
 private fun agentTextMessage(role: String, content: String): JsonObject = buildJsonObject {
     put("role", role)
@@ -154,7 +246,8 @@ internal fun parseAgentToolDecision(
                 !(allowProviderWebSearchCall && isProviderWebSearchToolCall(element))
         },
         webSearchUsed = webSearchUsed,
-        providerWebSearchRequested = providerWebSearchRequested
+        providerWebSearchRequested = providerWebSearchRequested,
+        usage = agentTokenUsage(root)
     )
 }
 private fun parseLocalAgentToolCall(element: JsonElement, response: String): AgentToolCall? {
@@ -410,113 +503,158 @@ class DayAgentService(private val context: Context) {
             }
             add(agentUserMessage(question, imageAttachment))
         }
-        if (AiProviderPresets.shouldUseResponses(settings.profile)) {
-            return@withContext OpenAiResponsesAgentRunner().chat(
+        val telemetry = DayAgentTurnTelemetry(settings.profile.id)
+        try {
+            if (AiProviderPresets.shouldUseResponses(settings.profile)) {
+                return@withContext OpenAiResponsesAgentRunner().chat(
+                    settings = settings,
+                    chatMessages = messages,
+                    includeMemoryTool = memoryToolAvailable,
+                    onStatus = onStatus,
+                    onDelta = onDelta,
+                    onStreamReset = onStreamReset,
+                    executeTool = ::executeTurnTool,
+                    telemetry = telemetry
+                )
+            }
+            val completedOneShotTools = mutableSetOf<AgentToolName>()
+            val evidenceKeys = mutableSetOf<String>()
+            val baseMessages = messages.toList()
+            val closedToolFacts = linkedMapOf<String, AgentToolResult>()
+            var latestRoundFacts = emptyList<Pair<String, AgentToolResult>>()
+            var latestRoundMessages = emptyList<JsonObject>()
+            fun rebuildChatContext() {
+                messages.clear()
+                messages += baseMessages
+                if (closedToolFacts.isNotEmpty()) {
+                    messages += agentTextMessage(
+                        "system",
+                        buildJsonObject {
+                            put("kind", "local_tool_facts")
+                            put("trust", "untrusted_local_data")
+                            put("sourceHash", facts.sourceHash)
+                            put("results", buildJsonArray {
+                                closedToolFacts.values.forEach { result ->
+                                    add(buildJsonObject {
+                                        put("tool", result.name.name)
+                                        put("content", result.content)
+                                    })
+                                }
+                            })
+                        }.toString()
+                    )
+                }
+                messages += latestRoundMessages
+            }
+
+            for (round in 0 until MaxAgentToolRounds) {
+                onStatus(AgentRunStatus(AgentRunStatusIcon.THINKING, "正在思考"))
+                fun requestDecision(forceMiMoWebSearch: Boolean): AgentToolDecision {
+                    val decisionBody = chatTransport.agentBody(
+                        settings = settings,
+                        messages = messages + agentTextMessage(
+                            "system",
+                            DayAgentPrompts.ToolDecisionStage
+                        ),
+                        stream = false,
+                        includeTools = true,
+                        includeMemoryTool = memoryToolAvailable,
+                        forceMiMoWebSearch = forceMiMoWebSearch,
+                        excludedTools = completedOneShotTools
+                    )
+                    telemetry.requestStarted()
+                    val response = chatTransport.post(settings, decisionBody)
+                    val parsed = parseAgentToolDecision(
+                        response = response,
+                        allowProviderWebSearchCall = miMoWebSearchAvailable
+                    )
+                    telemetry.recordUsage(parsed.usage)
+                    return parsed
+                }
+                var decision = requestDecision(forceMiMoWebSearch = false)
+                if (decision.providerWebSearchRequested && !decision.webSearchUsed) {
+                    onStatus(AgentRunStatus(AgentRunStatusIcon.SEARCH, "联网搜索"))
+                    decision = requestDecision(forceMiMoWebSearch = true)
+                    if (decision.providerWebSearchRequested && !decision.webSearchUsed) {
+                        throw IllegalStateException("MiMo 联网搜索没有返回搜索结果，请稍后重试")
+                    }
+                }
+                telemetry.recordDecisionRound(decision.calls.size)
+                if (decision.calls.isNotEmpty()) {
+                    val action = decision.calls.first().name.runStatus().text.removePrefix("读取")
+                    val note = decision.content.trim().take(120).ifBlank {
+                        "我先确认$action，再继续处理。"
+                    }
+                    onStatus(
+                        AgentRunStatus(
+                            icon = AgentRunStatusIcon.THINKING,
+                            text = "准备下一步",
+                            detail = note
+                        )
+                    )
+                }
+                if (decision.webSearchUsed) {
+                    onStatus(AgentRunStatus(AgentRunStatusIcon.SEARCH, "联网搜索"))
+                }
+                if (decision.unparsedToolCallCount > 0) {
+                    throw IllegalStateException(
+                        "模型返回了 ${decision.unparsedToolCallCount} 个无法识别的工具调用，请重试"
+                    )
+                }
+                if (decision.calls.isEmpty()) {
+                    val finalMessages = if (decision.webSearchUsed && decision.content.isNotBlank()) {
+                        messages + agentTextMessage(
+                            "system",
+                            buildJsonObject {
+                                put("kind", "provider_web_search_result")
+                                put("trust", "untrusted_external_data")
+                                put("content", decision.content)
+                            }.toString()
+                        )
+                    } else {
+                        messages
+                    }
+                    return@withContext streamFinalAnswer(
+                        settings = settings,
+                        messages = finalMessages,
+                        onStatus = onStatus,
+                        onDelta = onDelta,
+                        onStreamReset = onStreamReset,
+                        telemetry = telemetry
+                    )
+                }
+
+                val roundResults = decision.calls.map { call ->
+                    onStatus(call.name.runStatus())
+                    executeTurnTool(call).also {
+                        if (call.name.isOneShotPerTurn) completedOneShotTools += call.name
+                    }
+                }
+                telemetry.recordToolResults(roundResults)
+                val addedEvidence = decision.calls
+                    .map { call -> evidenceKeys.add("${facts.sourceHash}\u0000${call.cacheKey()}") }
+                    .any { it }
+                latestRoundFacts.forEach { (key, result) -> closedToolFacts.putIfAbsent(key, result) }
+                latestRoundFacts = decision.calls.zip(roundResults).map { (call, result) ->
+                    call.cacheKey() to result
+                }
+                latestRoundMessages = listOf(decision.assistantMessage) +
+                    roundResults.map { it.asAgentToolMessage() }
+                rebuildChatContext()
+                if (!addedEvidence) break
+            }
+
+            return@withContext streamFinalAnswer(
                 settings = settings,
-                chatMessages = messages,
-                includeMemoryTool = memoryToolAvailable,
+                messages = messages,
                 onStatus = onStatus,
                 onDelta = onDelta,
                 onStreamReset = onStreamReset,
-                executeTool = ::executeTurnTool
+                telemetry = telemetry
             )
+        } finally {
+            telemetry.logSummary()
         }
-        val completedOneShotTools = mutableSetOf<AgentToolName>()
-        var forcedMiMoWebSearchRetry = false
-        for (round in 0 until MaxAgentToolRounds) {
-            onStatus(AgentRunStatus(AgentRunStatusIcon.THINKING, "正在思考"))
-            val decisionBody = chatTransport.agentBody(
-                settings = settings,
-                messages = messages + agentTextMessage(
-                    "system",
-                    DayAgentPrompts.ToolDecisionStage
-                ),
-                stream = false,
-                includeTools = true,
-                includeMemoryTool = memoryToolAvailable,
-                forceMiMoWebSearch = forcedMiMoWebSearchRetry,
-                excludedTools = completedOneShotTools
-            )
-            val decision = parseAgentToolDecision(
-                response = chatTransport.post(settings, decisionBody),
-                allowProviderWebSearchCall = miMoWebSearchAvailable
-            )
-            if (decision.providerWebSearchRequested && !decision.webSearchUsed) {
-                if (forcedMiMoWebSearchRetry) {
-                    throw IllegalStateException("MiMo 联网搜索没有返回搜索结果，请稍后重试")
-                }
-                // A function-shaped WEB_SEARCH call is not executable inside SleepDown. Reissue
-                // the same provider turn with MiMo's real server-side plugin forced, rather than
-                // misreporting it as an unknown local function or fabricating a local result.
-                forcedMiMoWebSearchRetry = true
-                onStatus(AgentRunStatus(AgentRunStatusIcon.SEARCH, "联网搜索"))
-                continue
-            }
-            forcedMiMoWebSearchRetry = false
-            if (decision.calls.isNotEmpty()) {
-                val action = decision.calls.first().name.runStatus().text.removePrefix("读取")
-                val note = decision.content.trim().take(120).ifBlank {
-                    "我先确认$action，再继续处理。"
-                }
-                onStatus(
-                    AgentRunStatus(
-                        icon = AgentRunStatusIcon.THINKING,
-                        text = "准备下一步",
-                        detail = note
-                    )
-                )
-            }
-            if (decision.webSearchUsed) {
-                onStatus(AgentRunStatus(AgentRunStatusIcon.SEARCH, "联网搜索"))
-            }
-            if (decision.unparsedToolCallCount > 0) {
-                throw IllegalStateException(
-                    "模型返回了 ${decision.unparsedToolCallCount} 个无法识别的工具调用，请重试"
-                )
-            }
-            if (decision.calls.isEmpty()) {
-                val finalMessages = if (decision.webSearchUsed && decision.content.isNotBlank()) {
-                    messages + agentTextMessage(
-                        "system",
-                        buildJsonObject {
-                            put("kind", "provider_web_search_result")
-                            put("trust", "untrusted_external_data")
-                            put("content", decision.content)
-                        }.toString()
-                    )
-                } else {
-                    messages
-                }
-                return@withContext streamFinalAnswer(
-                    settings = settings,
-                    messages = finalMessages,
-                    onStatus = onStatus,
-                    onDelta = onDelta,
-                    onStreamReset = onStreamReset
-                )
-            }
-
-            messages += decision.assistantMessage
-            /*
-             * Execute and report each function call in the exact order emitted by the model.
-             * Do not batch status labels before execution: that made the UI look like a canned
-             * workflow and hid repeated calls of the same tool.
-             */
-            decision.calls.forEach { call ->
-                onStatus(call.name.runStatus())
-                val result = executeTurnTool(call)
-                messages += result.asAgentToolMessage()
-                if (call.name.isOneShotPerTurn) completedOneShotTools += call.name
-            }
-        }
-
-        streamFinalAnswer(
-            settings = settings,
-            messages = messages,
-            onStatus = onStatus,
-            onDelta = onDelta,
-            onStreamReset = onStreamReset
-        )
     }
 
     /**
@@ -529,9 +667,11 @@ class DayAgentService(private val context: Context) {
         messages: List<JsonObject>,
         onStatus: (AgentRunStatus) -> Unit,
         onDelta: (String) -> Unit,
-        onStreamReset: () -> Unit
+        onStreamReset: () -> Unit,
+        telemetry: DayAgentTurnTelemetry
     ): String {
         onStatus(AgentRunStatus(AgentRunStatusIcon.THINKING, "整理结果"))
+        telemetry.finalAnswerStarted()
         val finalMessages = messages + agentTextMessage(
             "system",
             DayAgentPrompts.FinalAnswerStage
@@ -543,8 +683,16 @@ class DayAgentService(private val context: Context) {
             includeTools = false
         )
         return try {
+            telemetry.requestStarted()
             val gate = AgentFinalOutputGate(onDelta)
-            gate.finish(chatTransport.stream(settings, finalBody, gate::accept))
+            gate.finish(
+                chatTransport.stream(
+                    settings = settings,
+                    body = finalBody,
+                    onDelta = gate::accept,
+                    onUsage = telemetry::recordUsage
+                )
+            )
         } catch (error: Throwable) {
             if (error !is MissingAgentBodyException && error !is AgentProtocolViolationException) {
                 throw error
@@ -561,7 +709,10 @@ class DayAgentService(private val context: Context) {
                 stream = false,
                 includeTools = false
             )
-            val retryContent = parseFullChatContent(chatTransport.post(settings, retryBody))
+            telemetry.requestStarted()
+            val retryResponse = chatTransport.post(settings, retryBody)
+            telemetry.recordUsage(parseAgentTokenUsage(retryResponse))
+            val retryContent = parseFullChatContent(retryResponse)
             if (containsLeakedAgentFunctionProtocol(retryContent)) {
                 throw AgentProtocolViolationException()
             }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/background/DayAgentBackground.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/background/DayAgentBackground.kt
@@ -12,7 +12,6 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.IBinder
 import androidx.core.content.ContextCompat
 import java.time.LocalDate
@@ -262,7 +261,7 @@ open class DayAgentForegroundServiceHost : Service() {
     }
 
     private fun runningNotification(): Notification {
-        val builder = Notification.Builder(this, RUNNING_CHANNEL_ID)
+        return Notification.Builder(this, RUNNING_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_agent_thinking)
             .setContentTitle("今日助手")
             .setContentText("模型思考中")
@@ -270,28 +269,10 @@ open class DayAgentForegroundServiceHost : Service() {
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
-            .setCategory(Notification.CATEGORY_PROGRESS)
+            .setCategory(Notification.CATEGORY_SERVICE)
             .setColor(0xFF0A84FF.toInt())
             .requestPromotedOngoing("思考中")
-        if (Build.VERSION.SDK_INT >= 36) {
-            // Fake three-stage progress: the marker sits in the "parsing" range while the
-            // model streams, using the same style as the AI import live update.
-            builder.setStyle(
-                Notification.ProgressStyle()
-                    .setStyledByProgress(true)
-                    .setProgressSegments(
-                        listOf(
-                            Notification.ProgressStyle.Segment(DAY_AGENT_STAGE_COUNT)
-                                .setColor(0xFF0A84FF.toInt())
-                        )
-                    )
-                    .setProgress(DAY_AGENT_FAKE_RUNNING_STAGE)
-                    .setProgressTrackerIcon(whiteDotProgressTrackerIcon(this))
-            )
-        } else {
-            builder.setProgress(0, 0, true)
-        }
-        return builder.build()
+            .build()
     }
 
     private fun completedNotification(): Notification =
@@ -370,9 +351,6 @@ open class DayAgentForegroundServiceHost : Service() {
         private const val RESULT_CHANNEL_ID = "day_agent_result"
         private const val RUNNING_NOTIFICATION_ID = 20260731
         private const val RESULT_NOTIFICATION_ID = 20260732
-        private const val DAY_AGENT_STAGE_COUNT = 6
-        private const val DAY_AGENT_FAKE_RUNNING_STAGE = 2
-
         fun startThinking(context: Context) {
             ContextCompat.startForegroundService(
                 context,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/background/DayAgentBackground.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/agent/background/DayAgentBackground.kt
@@ -12,6 +12,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.IBinder
 import androidx.core.content.ContextCompat
 import java.time.LocalDate
@@ -260,8 +261,8 @@ open class DayAgentForegroundServiceHost : Service() {
         )
     }
 
-    private fun runningNotification(): Notification =
-        Notification.Builder(this, RUNNING_CHANNEL_ID)
+    private fun runningNotification(): Notification {
+        val builder = Notification.Builder(this, RUNNING_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_agent_thinking)
             .setContentTitle("今日助手")
             .setContentText("模型思考中")
@@ -271,9 +272,27 @@ open class DayAgentForegroundServiceHost : Service() {
             .setShowWhen(false)
             .setCategory(Notification.CATEGORY_PROGRESS)
             .setColor(0xFF0A84FF.toInt())
-            .setProgress(0, 0, true)
             .requestPromotedOngoing("思考中")
-            .build()
+        if (Build.VERSION.SDK_INT >= 36) {
+            // Fake three-stage progress: the marker sits in the "parsing" range while the
+            // model streams, using the same style as the AI import live update.
+            builder.setStyle(
+                Notification.ProgressStyle()
+                    .setStyledByProgress(true)
+                    .setProgressSegments(
+                        listOf(
+                            Notification.ProgressStyle.Segment(DAY_AGENT_STAGE_COUNT)
+                                .setColor(0xFF0A84FF.toInt())
+                        )
+                    )
+                    .setProgress(DAY_AGENT_FAKE_RUNNING_STAGE)
+                    .setProgressTrackerIcon(whiteDotProgressTrackerIcon(this))
+            )
+        } else {
+            builder.setProgress(0, 0, true)
+        }
+        return builder.build()
+    }
 
     private fun completedNotification(): Notification =
         Notification.Builder(this, RESULT_CHANNEL_ID)
@@ -351,6 +370,8 @@ open class DayAgentForegroundServiceHost : Service() {
         private const val RESULT_CHANNEL_ID = "day_agent_result"
         private const val RUNNING_NOTIFICATION_ID = 20260731
         private const val RESULT_NOTIFICATION_ID = 20260732
+        private const val DAY_AGENT_STAGE_COUNT = 6
+        private const val DAY_AGENT_FAKE_RUNNING_STAGE = 2
 
         fun startThinking(context: Context) {
             ContextCompat.startForegroundService(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseColorPicker.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseColorPicker.kt
@@ -1,0 +1,141 @@
+package com.xiaomanjun.sleepdownschedule.feature.course.editor
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import com.kyant.backdrop.Backdrop
+import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
+import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.QuickSheetLiquidAction
+import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.SleepDownDesignTokens
+import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.SleepDownPickerDialog
+import com.xiaomanjun.sleepdownschedule.glass.ui.DefaultCourseCardPalette
+import com.xiaomanjun.sleepdownschedule.glass.ui.LocalCourseCardPalette
+import com.xiaomanjun.sleepdownschedule.glass.ui.appUsesDarkTheme
+
+@Composable
+internal fun CourseColorPicker(
+    show: Boolean,
+    selectedColorArgb: Long?,
+    backdrop: Backdrop?,
+    config: ScheduleConfigEntity,
+    renderInRootScaffold: Boolean,
+    onDismissRequest: () -> Unit,
+    onDismissFinished: () -> Unit,
+    onColorSelected: (Long?) -> Unit
+) {
+    val palette = LocalCourseCardPalette.current.ifEmpty { DefaultCourseCardPalette }
+    var pendingColor by remember(show, selectedColorArgb) { mutableStateOf(selectedColorArgb) }
+    val foreground = if (appUsesDarkTheme(config)) Color.White else Color(0xFF111111)
+    SleepDownPickerDialog(
+        show = show,
+        title = "课程颜色",
+        onDismissRequest = onDismissRequest,
+        onDismissFinished = onDismissFinished,
+        backdrop = backdrop,
+        config = config,
+        renderInRootScaffold = renderInRootScaffold,
+        contentPadding = PaddingValues(horizontal = 4.dp, vertical = 2.dp),
+        contentSpacing = 14.dp,
+        blurRadius = 10.dp
+    ) {
+        CompositionLocalProvider(LocalContentColor provides foreground) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                QuickSheetLiquidAction(
+                    label = "自动",
+                    enabled = true,
+                    backdrop = backdrop,
+                    config = config,
+                    primary = pendingColor == null,
+                    modifier = Modifier.fillMaxWidth(),
+                    height = 42.dp,
+                    onClick = { pendingColor = null }
+                )
+                Text(
+                    text = "当前课程色板",
+                    color = foreground.copy(alpha = 0.68f),
+                    style = MaterialTheme.typography.labelMedium
+                )
+                LazyRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    items(palette, key = { it }) { colorArgb ->
+                        val selected = pendingColor == colorArgb
+                        Surface(
+                            modifier = Modifier.size(36.dp),
+                            shape = RoundedCornerShape(50),
+                            color = Color(colorArgb.toInt()),
+                            border = BorderStroke(
+                                if (selected) 3.dp else 1.dp,
+                                if (selected) MaterialTheme.colorScheme.primary
+                                else foreground.copy(alpha = 0.28f)
+                            ),
+                            onClick = { pendingColor = colorArgb }
+                        ) {}
+                    }
+                }
+                top.yukonga.miuix.kmp.basic.ColorPalette(
+                    color = Color((pendingColor ?: palette.first()).toInt()),
+                    onColorChanged = { color ->
+                        pendingColor = color.copy(alpha = 1f).toArgb().toLong() and 0xFFFFFFFFL
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    rows = 7,
+                    hueColumns = 12,
+                    includeGrayColumn = true,
+                    showPreview = true,
+                    cornerRadius = 16.dp,
+                    indicatorRadius = 10.dp
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(SleepDownDesignTokens.Dialog.ActionSpacing)
+                ) {
+                    QuickSheetLiquidAction(
+                        label = "取消",
+                        enabled = true,
+                        backdrop = backdrop,
+                        config = config,
+                        modifier = Modifier.weight(1f),
+                        height = SleepDownDesignTokens.CenteredDialog.ActionHeight,
+                        onClick = onDismissRequest
+                    )
+                    QuickSheetLiquidAction(
+                        label = "确定",
+                        enabled = true,
+                        backdrop = backdrop,
+                        config = config,
+                        primary = true,
+                        modifier = Modifier.weight(1f),
+                        height = SleepDownDesignTokens.CenteredDialog.ActionHeight,
+                        onClick = {
+                            onColorSelected(pendingColor)
+                            onDismissRequest()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseEditorUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseEditorUi.kt
@@ -209,6 +209,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color as ComposeColor
+import androidx.compose.ui.graphics.toArgb
 import top.yukonga.miuix.kmp.squircle.squircleSurface
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.isSpecified
@@ -1024,6 +1025,10 @@ private fun CourseEditorFormPage(
             item(key = "course-color", contentType = "picker") {
                 CourseEditorColorValue(
                     colorArgb = draft.customColorArgb,
+                    automaticColorArgb = courseCardBaseColor(
+                        config,
+                        course?.copy(customColorArgb = null)
+                    ).toArgb().toLong() and 0xFFFFFFFFL,
                     onClick = onOpenColorPicker
                 )
             }
@@ -1339,11 +1344,11 @@ private fun CourseEditorPickerValue(
 @Composable
 private fun CourseEditorColorValue(
     colorArgb: Long?,
+    automaticColorArgb: Long,
     onClick: () -> Unit
 ) {
     val contentColor = LocalContentColor.current
-    val palette = LocalCourseCardPalette.current.ifEmpty { DefaultCourseCardPalette }
-    val previewColor = colorArgb ?: palette.first()
+    val previewColor = colorArgb ?: automaticColorArgb
     Box(
         Modifier
             .fillMaxWidth()

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseEditorUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseEditorUi.kt
@@ -389,6 +389,7 @@ private data class CourseEditorDraft(
     val periodEnd: Int,
     val customStartTime: String?,
     val customEndTime: String?,
+    val customColorArgb: Long?,
     val weeks: Set<Int>,
     val parity: WeekParity,
     val note: String
@@ -624,6 +625,7 @@ private fun courseEditorDraft(
         periodEnd = course?.periods?.maxOrNull() ?: (periodValues.firstOrNull() ?: 1),
         customStartTime = course?.customStartTime,
         customEndTime = course?.customEndTime,
+        customColorArgb = course?.customColorArgb,
         weeks = activeWeeks,
         parity = selectionMode.toWeekParity(),
         note = course?.note.orEmpty()
@@ -641,7 +643,8 @@ internal fun courseEditorOriginalForWeekday(
 
 private fun CourseEditorDraft.toCourses(
     originals: List<CourseEntity>,
-    periodValues: List<Int>
+    periodValues: List<Int>,
+    allowCustomColorOverride: Boolean
 ): List<CourseEntity> {
     val originalWeekdays = originals.map(CourseEntity::weekday).toSet()
     val originalWeeks = originals.flatMap(CourseEntity::weeks).toSet()
@@ -669,7 +672,11 @@ private fun CourseEditorDraft.toCourses(
             note = note.trim().ifBlank { null },
             customStartTime = customStartTime,
             customEndTime = customEndTime,
-            customColorArgb = original?.customColorArgb ?: originals.firstOrNull()?.customColorArgb,
+            customColorArgb = if (allowCustomColorOverride) {
+                customColorArgb
+            } else {
+                original?.customColorArgb ?: originals.firstOrNull()?.customColorArgb
+            },
             scheduleId = original?.scheduleId ?: originals.firstOrNull()?.scheduleId ?: 0
         )
     }
@@ -713,8 +720,10 @@ fun NormalizedCourseEditorScreen(
     var error by remember { mutableStateOf<String?>(null) }
     var pickerRequest by remember { mutableStateOf<CourseEditorPickerRequest?>(null) }
     var pickerVisible by remember { mutableStateOf(false) }
+    var colorPickerPage by remember { mutableStateOf<Int?>(null) }
+    var colorPickerVisible by remember { mutableStateOf(false) }
     val currentPage = pagerState.currentPage.coerceIn(editorGroups.indices)
-    val pagerIndicatorVisible = editorGroups.size > 1 && pickerRequest == null
+    val pagerIndicatorVisible = editorGroups.size > 1 && pickerRequest == null && colorPickerPage == null
 
     SideEffect {
         onPagerPresentationChange?.invoke(
@@ -734,7 +743,7 @@ fun NormalizedCourseEditorScreen(
             modifier = Modifier.fillMaxSize(),
             beyondViewportPageCount = 1,
             pageSpacing = 10.dp,
-            userScrollEnabled = pickerRequest == null,
+            userScrollEnabled = pickerRequest == null && colorPickerPage == null,
             key = { page -> editorGroups[page].representative?.id ?: Long.MIN_VALUE }
         ) { page ->
             val group = editorGroups[page]
@@ -754,7 +763,11 @@ fun NormalizedCourseEditorScreen(
                 onCancel = onCancel,
                 onSave = {
                     val currentDraft = drafts.getValue(page)
-                    val edited = currentDraft.toCourses(group.courses, periodValues)
+                    val edited = currentDraft.toCourses(
+                        originals = group.courses,
+                        periodValues = periodValues,
+                        allowCustomColorOverride = courseCardAllowsCustomOverrides(config)
+                    )
                     when {
                         currentDraft.name.isBlank() -> error = "课程名称不能为空"
                         currentDraft.weekdays.isEmpty() -> error = "请选择星期"
@@ -775,6 +788,10 @@ fun NormalizedCourseEditorScreen(
                 onOpenPicker = {
                     pickerRequest = it
                     pickerVisible = true
+                },
+                onOpenColorPicker = {
+                    colorPickerPage = page
+                    colorPickerVisible = true
                 },
                 pageCount = editorGroups.size
             )
@@ -802,6 +819,23 @@ fun NormalizedCourseEditorScreen(
                 }
             )
         }
+        colorPickerPage?.let { page ->
+            CourseColorPicker(
+                show = colorPickerVisible,
+                selectedColorArgb = drafts.getValue(page).customColorArgb,
+                backdrop = backdrop,
+                config = config,
+                renderInRootScaffold = pickerRenderInRootScaffold,
+                onDismissRequest = { colorPickerVisible = false },
+                onDismissFinished = {
+                    if (!colorPickerVisible) colorPickerPage = null
+                },
+                onColorSelected = { color ->
+                    drafts = drafts + (page to drafts.getValue(page).copy(customColorArgb = color))
+                    error = null
+                }
+            )
+        }
     }
 }
 
@@ -821,6 +855,7 @@ private fun CourseEditorFormPage(
     onSave: () -> Unit,
     onDelete: (() -> Unit)?,
     onOpenPicker: (CourseEditorPickerRequest) -> Unit,
+    onOpenColorPicker: () -> Unit,
     pageCount: Int
 ) {
     // This form lives on the wallpaper-sampling CourseGlassCard. Its complete foreground domain
@@ -984,6 +1019,14 @@ private fun CourseEditorFormPage(
                 backdrop = backdrop,
                 config = config
             ) { courseWeekSelectionModeLabel(it) }
+        }
+        if (courseCardAllowsCustomOverrides(config)) {
+            item(key = "course-color", contentType = "picker") {
+                CourseEditorColorValue(
+                    colorArgb = draft.customColorArgb,
+                    onClick = onOpenColorPicker
+                )
+            }
         }
         item(key = "note", contentType = "field") {
             DialogCapsuleField(
@@ -1285,6 +1328,49 @@ private fun CourseEditorPickerValue(
                     painter = painterResource(R.drawable.ic_arrow_back),
                     contentDescription = "打开${title}选择器",
                     tint = buttonTextColor.copy(alpha = 0.62f),
+                    modifier = Modifier.size(18.dp).graphicsLayer { rotationZ = 180f }
+                )
+            },
+            onClick = onClick
+        )
+    }
+}
+
+@Composable
+private fun CourseEditorColorValue(
+    colorArgb: Long?,
+    onClick: () -> Unit
+) {
+    val contentColor = LocalContentColor.current
+    val palette = LocalCourseCardPalette.current.ifEmpty { DefaultCourseCardPalette }
+    val previewColor = colorArgb ?: palette.first()
+    Box(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .height(42.dp)
+            .clip(RoundedCornerShape(18.dp))
+    ) {
+        MiuixBasicComponent(
+            title = "课程颜色",
+            titleColor = MiuixBasicComponentDefaults.titleColor(
+                color = contentColor,
+                disabledColor = contentColor.copy(alpha = 0.38f)
+            ),
+            modifier = Modifier.fillMaxSize(),
+            insideMargin = PaddingValues(horizontal = 16.dp, vertical = 0.dp),
+            endActions = {
+                Surface(
+                    modifier = Modifier.size(20.dp),
+                    shape = RoundedCornerShape(50),
+                    color = ComposeColor(previewColor.toInt()),
+                    border = BorderStroke(1.dp, contentColor.copy(alpha = 0.28f))
+                ) {}
+                Spacer(Modifier.width(8.dp))
+                Icon(
+                    painter = painterResource(R.drawable.ic_arrow_back),
+                    contentDescription = "打开课程颜色选择器",
+                    tint = contentColor.copy(alpha = 0.62f),
                     modifier = Modifier.size(18.dp).graphicsLayer { rotationZ = 180f }
                 )
             },

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/management/CourseManagementUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/management/CourseManagementUi.kt
@@ -71,6 +71,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -535,6 +538,7 @@ internal fun CourseManagementDetailPage(
     }
     var pickerRequest by remember { mutableStateOf<CourseEditorPickerRequest?>(null) }
     var pickerVisible by remember { mutableStateOf(false) }
+    var colorPickerVisible by remember { mutableStateOf(false) }
     var showSaveChangesDialog by remember(group.key) { mutableStateOf(false) }
     var validationMessage by remember(group.key) { mutableStateOf<String?>(null) }
     var pendingDelete by remember(group.key) { mutableStateOf<PendingArrangementDelete?>(null) }
@@ -675,6 +679,7 @@ internal fun CourseManagementDetailPage(
                     onNameChange = { name = it },
                     selectedColor = selectedColor,
                     onColorSelected = { selectedColor = it },
+                    onOpenColorPicker = { colorPickerVisible = true },
                     config = state.config
                 )
             }
@@ -741,6 +746,16 @@ internal fun CourseManagementDetailPage(
                 }
             )
         }
+        CourseColorPicker(
+            show = colorPickerVisible,
+            selectedColorArgb = selectedColor,
+            backdrop = pickerBackdrop,
+            config = state.config,
+            renderInRootScaffold = true,
+            onDismissRequest = { colorPickerVisible = false },
+            onDismissFinished = {},
+            onColorSelected = { selectedColor = it }
+        )
         if (showSaveChangesDialog) {
             val canSave = arrangements.isEmpty() || name.trim().isNotBlank()
             LiquidAlertDialog(
@@ -857,6 +872,7 @@ private fun CourseIdentityCard(
     onNameChange: (String) -> Unit,
     selectedColor: Long?,
     onColorSelected: (Long?) -> Unit,
+    onOpenColorPicker: () -> Unit,
     config: ScheduleConfigEntity
 ) {
     CourseManagementSettingsSection(title = "课程信息") {
@@ -901,7 +917,7 @@ private fun CourseIdentityCard(
                         )
                     }
                     Icon(
-                        painter = painterResource(R.drawable.ic_course_color_auto),
+                        imageVector = Icons.Filled.AutoAwesome,
                         contentDescription = "自动课程颜色",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.size(19.dp)
@@ -940,6 +956,31 @@ private fun CourseIdentityCard(
                             )
                         }
                     }
+                }
+                val customSelected = selectedColor != null && selectedColor !in palette.take(6)
+                Box(
+                    Modifier.size(34.dp).clip(RoundedCornerShape(50))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .then(
+                            if (customSelected) {
+                                Modifier.border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(50))
+                            } else {
+                                Modifier
+                            }
+                        )
+                        .clickable(onClick = onOpenColorPicker),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Palette,
+                        contentDescription = "打开调色盘",
+                        tint = if (customSelected) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            MaterialTheme.colorScheme.onSurfaceVariant
+                        },
+                        modifier = Modifier.size(19.dp)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/home/day/HomeScheduleUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/home/day/HomeScheduleUi.kt
@@ -114,7 +114,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -502,57 +501,39 @@ fun HomeDateTitle(
 ) {
     val color = homeForegroundColor(state.config)
     val interactionSource = remember { MutableInteractionSource() }
-    BoxWithConstraints(
+    Column(
         modifier = Modifier
-            .height(42.dp)
-            .clickable(interactionSource = interactionSource, indication = null, onClick = onReturnCurrent)
+            .clickable(interactionSource = interactionSource, indication = null, onClick = onReturnCurrent),
+        verticalArrangement = Arrangement.Center
     ) {
-        val density = LocalDensity.current
-        val requestedLineHeightPx = with(density) { 18.sp.toPx() + 21.sp.toPx() }
-        val availableHeightPx = with(density) { maxHeight.toPx() }
-        val lineHeightSafetyPx = with(density) { 2.dp.toPx() }
-        // Keep the accepted 16sp/19sp appearance at normal font scale. If accessibility font
-        // scaling would make the two physical line boxes exceed the same 42dp occupied by the
-        // adjacent top-bar buttons, shrink both lines by only the overflow ratio. Reserve a small
-        // descent/rounding allowance so the second line is not clipped at unusual density scales.
-        val lineScale = (
-            (availableHeightPx - lineHeightSafetyPx).coerceAtLeast(1f) /
-                requestedLineHeightPx.coerceAtLeast(1f)
-            )
-            .coerceIn(0.1f, 1f)
-        Column(
-            modifier = Modifier.fillMaxHeight(),
-            verticalArrangement = Arrangement.Center
-        ) {
-            HomeReadableText(
-                when {
-                    beforeScheduleTerm -> "当前暂未开学"
-                    afterScheduleTerm -> "学期已结束"
-                    showReturnToCurrentWeekHint -> "点击此处回到本周"
-                    else -> "第${displayWeek}周"
-                },
-                style = MaterialTheme.typography.labelMedium.copy(
-                    fontSize = (16f * lineScale).sp,
-                    lineHeight = (18f * lineScale).sp
-                ),
-                fontWeight = FontWeight.Medium,
-                color = color.copy(alpha = 0.68f),
-                maxLines = 1,
-                softWrap = false
-            )
-            HomeReadableText(
-                "${displayDate.monthValue}月${displayDate.dayOfMonth}日 周${weekdayLabel(displayDate.dayOfWeek.toChineseWeekday())}",
-                style = MaterialTheme.typography.titleMedium.copy(
-                    fontSize = (19f * lineScale).sp,
-                    lineHeight = (21f * lineScale).sp
-                ),
-                fontWeight = FontWeight.Bold,
-                color = color,
-                maxLines = 1,
-                softWrap = false,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
+        HomeReadableText(
+            when {
+                beforeScheduleTerm -> "当前暂未开学"
+                afterScheduleTerm -> "学期已结束"
+                showReturnToCurrentWeekHint -> "点击此处回到本周"
+                else -> "第${displayWeek}周"
+            },
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontSize = 16.sp,
+                lineHeight = 18.sp
+            ),
+            fontWeight = FontWeight.Medium,
+            color = color.copy(alpha = 0.68f),
+            maxLines = 1,
+            softWrap = false
+        )
+        HomeReadableText(
+            "${displayDate.monthValue}月${displayDate.dayOfMonth}日 周${weekdayLabel(displayDate.dayOfWeek.toChineseWeekday())}",
+            style = MaterialTheme.typography.titleMedium.copy(
+                fontSize = 19.sp,
+                lineHeight = 21.sp
+            ),
+            fontWeight = FontWeight.Bold,
+            color = color,
+            maxLines = 1,
+            softWrap = false,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/home/week/WeekScheduleUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/home/week/WeekScheduleUi.kt
@@ -233,17 +233,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.palette.graphics.Palette
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -4079,84 +4075,32 @@ fun WeekCourseBlock(
                     modifier = modifier.then(resizeHandleModifier)
                 )
             }
-            val cardEndsAtFinalPeriod = periodIndexes.indexOf(periodIndex)
-                .takeIf { it >= 0 }
-                ?.let { it + currentSpan >= periodIndexes.size } == true
-            if (cardEndsAtFinalPeriod && editMode && !customTimeLocked) {
-                // The final row sits inside the vertical scroll/pager clip. Use a zero-size anchor
-                // plus a non-clipping Popup for only this corner control, leaving the card layout
-                // unchanged while the handle floats above the grid and remains touchable.
-                val handlePopupPositionProvider = remember(density) {
-                    object : androidx.compose.ui.window.PopupPositionProvider {
-                        override fun calculatePosition(
-                            anchorBounds: IntRect,
-                            windowSize: IntSize,
-                            layoutDirection: LayoutDirection,
-                            popupContentSize: IntSize
-                        ): IntOffset {
-                            val overscan = with(density) { 4.dp.roundToPx() }
-                            return IntOffset(
-                                x = anchorBounds.left - popupContentSize.width + overscan,
-                                y = anchorBounds.top - popupContentSize.height + overscan
-                            )
-                        }
+            // Keep every resize control in the week grid's own layer. The edit-mode gutter above
+            // already provides the four drawing pixels used by this handle; promoting only the
+            // final-row handle to a window Popup made it render above the app's bottom dock.
+            AnimatedVisibility(
+                visible = editMode && !customTimeLocked,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .offset(x = 4.dp, y = 4.dp)
+                    .size(44.dp)
+                    .graphicsLayer {
+                        alpha = editControlHandoffProgress.coerceIn(0f, 1f)
+                        val handoffScale = 0.42f + editControlHandoffProgress * 0.58f
+                        scaleX = handoffScale
+                        scaleY = handoffScale
                     }
-                }
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .size(0.dp)
-                ) {
-                    Popup(
-                        popupPositionProvider = handlePopupPositionProvider,
-                        properties = PopupProperties(
-                            focusable = false,
-                            dismissOnBackPress = false,
-                            dismissOnClickOutside = false,
-                            clippingEnabled = false
-                        )
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(44.dp)
-                                .graphicsLayer {
-                                    alpha = editControlHandoffProgress.coerceIn(0f, 1f)
-                                    val handoffScale = 0.42f + editControlHandoffProgress * 0.58f
-                                    scaleX = handoffScale
-                                    scaleY = handoffScale
-                                    clip = false
-                                }
-                                .zIndex(6f)
-                        ) {
-                            renderResizeHandle(Modifier.fillMaxSize())
-                        }
-                    }
-                }
-            } else {
-                AnimatedVisibility(
-                    visible = editMode && !customTimeLocked,
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .offset(x = 4.dp, y = 4.dp)
-                        .size(44.dp)
-                        .graphicsLayer {
-                            alpha = editControlHandoffProgress.coerceIn(0f, 1f)
-                            val handoffScale = 0.42f + editControlHandoffProgress * 0.58f
-                            scaleX = handoffScale
-                            scaleY = handoffScale
-                        }
-                        .zIndex(6f),
-                    enter = fadeIn(tween(135, delayMillis = 45 + (startupIndex % 7) * 8)) +
-                        scaleIn(
-                            animationSpec = spring(dampingRatio = 0.52f, stiffness = 470f),
-                            initialScale = 0.32f,
-                            transformOrigin = TransformOrigin(0f, 0f)
-                        ),
-                    exit = fadeOut(tween(90)) +
-                        scaleOut(tween(125), targetScale = 0.55f, transformOrigin = TransformOrigin(0f, 0f))
-                ) {
-                    renderResizeHandle(Modifier.fillMaxSize())
-                }
+                    .zIndex(6f),
+                enter = fadeIn(tween(135, delayMillis = 45 + (startupIndex % 7) * 8)) +
+                    scaleIn(
+                        animationSpec = spring(dampingRatio = 0.52f, stiffness = 470f),
+                        initialScale = 0.32f,
+                        transformOrigin = TransformOrigin(0f, 0f)
+                    ),
+                exit = fadeOut(tween(90)) +
+                    scaleOut(tween(125), targetScale = 0.55f, transformOrigin = TransformOrigin(0f, 0f))
+            ) {
+                renderResizeHandle(Modifier.fillMaxSize())
             }
             }
         }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiEduImportProgressSession.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiEduImportProgressSession.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 data class AiEduImportProgress(
+    val taskId: String = "",
     val steps: List<String> = emptyList(),
     val routeLabel: String = "",
     val requestPreview: String = "",

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImport.kt
@@ -1515,7 +1515,11 @@ fun normalizeAiBaseUrlForProvider(providerId: String, value: String): String {
 }
 
 class AiScheduleImportService(private val context: Context) {
-    suspend fun parseScheduleFile(file: AiImportFile, settings: AiImportSettings): Result<AiScheduleImportResult> {
+    suspend fun parseScheduleFile(
+        file: AiImportFile,
+        settings: AiImportSettings,
+        onRequestStarted: () -> Unit
+    ): Result<AiScheduleImportResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
                 require(settings.apiKey.isNotBlank()) { "请先在设置中配置 AI API Key" }
@@ -1525,6 +1529,7 @@ class AiScheduleImportService(private val context: Context) {
                 val config = settings.toProviderConfig().normalizedForRequest()
                 val preprocess = DefaultScheduleFilePreprocessor(context).preprocess(file, config)
                 val input = preprocess.toScheduleInput(file)
+                onRequestStarted()
                 val result = when {
                     config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input)
                     else -> OpenAiCompatibleChatProvider().parseSchedule(config, input)
@@ -1539,7 +1544,12 @@ class AiScheduleImportService(private val context: Context) {
         }
     }
 
-    suspend fun parseScheduleText(text: String, sourceName: String, settings: AiImportSettings): Result<AiScheduleImportResult> {
+    suspend fun parseScheduleText(
+        text: String,
+        sourceName: String,
+        settings: AiImportSettings,
+        onRequestStarted: () -> Unit
+    ): Result<AiScheduleImportResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
                 require(settings.apiKey.isNotBlank()) { "请先在设置中配置 AI API Key" }
@@ -1549,6 +1559,7 @@ class AiScheduleImportService(private val context: Context) {
                 require(cleaned.count { !it.isWhitespace() } >= 40) { "当前页面可提取文本太少，请确认已经进入课表页面" }
                 val config = settings.toProviderConfig().normalizedForRequest()
                 val input = AiScheduleInput.ExtractedText(cleaned, sourceName)
+                onRequestStarted()
                 val result = when {
                     config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input)
                     else -> OpenAiCompatibleChatProvider().parseSchedule(config, input)
@@ -1568,7 +1579,8 @@ class AiScheduleImportService(private val context: Context) {
         screenshots: List<RenderedPageImage>,
         sourceName: String,
         warnings: List<String>,
-        settings: AiImportSettings
+        settings: AiImportSettings,
+        onRequestStarted: () -> Unit
     ): Result<AiScheduleImportResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
@@ -1589,6 +1601,7 @@ class AiScheduleImportService(private val context: Context) {
                 } else {
                     AiScheduleInput.CapturedPage(cleaned, screenshots, sourceName, warnings)
                 }
+                onRequestStarted()
                 val result = when {
                     config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input)
                     else -> OpenAiCompatibleChatProvider().parseSchedule(config, input)

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImport.kt
@@ -13,6 +13,7 @@ import android.graphics.Color
 import android.graphics.pdf.PdfRenderer
 import android.net.Uri
 import android.os.ParcelFileDescriptor
+import android.os.SystemClock
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
@@ -42,8 +43,10 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.intOrNull
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.BufferedReader
 import java.io.File
 import java.io.InputStream
+import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.InetAddress
 import java.net.InetSocketAddress
@@ -51,6 +54,7 @@ import java.net.Socket
 import java.net.URL
 import java.security.KeyStore
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.InflaterInputStream
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
@@ -65,6 +69,23 @@ enum class AiEndpointStyle {
     RESPONSES,
     KIMI_FILE_EXTRACT
 }
+
+enum class AiImportHttpPhase {
+    REQUEST_CREATED,
+    BODY_WRITE_START,
+    BODY_WRITE_END,
+    HEADERS_RECEIVED,
+    FIRST_EVENT,
+    BODY_READ_START,
+    STREAM_END
+}
+
+private data class AiImportNetworkContext(
+    val inputType: String,
+    val imageCount: Int = 0,
+    val screenshotCount: Int = 0,
+    val onPhase: (AiImportHttpPhase) -> Unit = {}
+)
 
 enum class StructuredOutputMode {
     JSON_SCHEMA,
@@ -1518,7 +1539,7 @@ class AiScheduleImportService(private val context: Context) {
     suspend fun parseScheduleFile(
         file: AiImportFile,
         settings: AiImportSettings,
-        onRequestStarted: () -> Unit
+        onHttpPhase: (AiImportHttpPhase) -> Unit
     ): Result<AiScheduleImportResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
@@ -1529,10 +1550,13 @@ class AiScheduleImportService(private val context: Context) {
                 val config = settings.toProviderConfig().normalizedForRequest()
                 val preprocess = DefaultScheduleFilePreprocessor(context).preprocess(file, config)
                 val input = preprocess.toScheduleInput(file)
-                onRequestStarted()
+                val networkContext = input.networkContext(
+                    if (file.isImage) "IMAGE" else "FILE",
+                    onHttpPhase
+                )
                 val result = when {
-                    config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input)
-                    else -> OpenAiCompatibleChatProvider().parseSchedule(config, input)
+                    config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input, networkContext)
+                    else -> OpenAiCompatibleChatProvider().parseSchedule(config, input, networkContext)
                 }
                 AiScheduleImportResult(
                     output = result.content,
@@ -1548,7 +1572,7 @@ class AiScheduleImportService(private val context: Context) {
         text: String,
         sourceName: String,
         settings: AiImportSettings,
-        onRequestStarted: () -> Unit
+        onHttpPhase: (AiImportHttpPhase) -> Unit
     ): Result<AiScheduleImportResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
@@ -1559,10 +1583,10 @@ class AiScheduleImportService(private val context: Context) {
                 require(cleaned.count { !it.isWhitespace() } >= 40) { "当前页面可提取文本太少，请确认已经进入课表页面" }
                 val config = settings.toProviderConfig().normalizedForRequest()
                 val input = AiScheduleInput.ExtractedText(cleaned, sourceName)
-                onRequestStarted()
+                val networkContext = input.networkContext("TEXT", onHttpPhase)
                 val result = when {
-                    config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input)
-                    else -> OpenAiCompatibleChatProvider().parseSchedule(config, input)
+                    config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input, networkContext)
+                    else -> OpenAiCompatibleChatProvider().parseSchedule(config, input, networkContext)
                 }
                 AiScheduleImportResult(
                     output = result.content,
@@ -1580,7 +1604,7 @@ class AiScheduleImportService(private val context: Context) {
         sourceName: String,
         warnings: List<String>,
         settings: AiImportSettings,
-        onRequestStarted: () -> Unit
+        onHttpPhase: (AiImportHttpPhase) -> Unit
     ): Result<AiScheduleImportResult> {
         return withContext(Dispatchers.IO) {
             runCatching {
@@ -1601,10 +1625,14 @@ class AiScheduleImportService(private val context: Context) {
                 } else {
                     AiScheduleInput.CapturedPage(cleaned, screenshots, sourceName, warnings)
                 }
-                onRequestStarted()
+                val networkContext = input.networkContext(
+                    inputType = "CAPTURED_PAGE",
+                    onHttpPhase = onHttpPhase,
+                    screenshotCount = screenshots.size
+                )
                 val result = when {
-                    config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input)
-                    else -> OpenAiCompatibleChatProvider().parseSchedule(config, input)
+                    config.endpointStyle == AiEndpointStyle.RESPONSES -> OpenAiResponsesProvider().parseSchedule(config, input, networkContext)
+                    else -> OpenAiCompatibleChatProvider().parseSchedule(config, input, networkContext)
                 }
                 val routeMessage = if (screenshots.isEmpty()) {
                     "已提取当前教务页面文本，使用 AI 解析。"
@@ -1625,7 +1653,8 @@ class AiScheduleImportService(private val context: Context) {
         draft: ImportDraft,
         instruction: String,
         history: AiEduImportProgress,
-        settings: AiImportSettings
+        settings: AiImportSettings,
+        onHttpPhase: (AiImportHttpPhase) -> Unit = {}
     ): Result<AiScheduleImportResult> = withContext(Dispatchers.IO) {
         runCatching {
             require(settings.apiKey.isNotBlank()) { "请先在设置中配置 AI API Key" }
@@ -1633,10 +1662,16 @@ class AiScheduleImportService(private val context: Context) {
             require(settings.profile.defaultModel.isNotBlank()) { "请先配置模型名称" }
             val config = settings.toProviderConfig().normalizedForRequest()
             val request = buildAiRevisionInput(draft, instruction, history)
+            val networkContext = AiImportNetworkContext(
+                inputType = "REVISION",
+                imageCount = history.screenshotPreviews.size,
+                screenshotCount = history.screenshotPreviews.size,
+                onPhase = onHttpPhase
+            )
             val result = when {
                 config.endpointStyle == AiEndpointStyle.RESPONSES ->
-                    OpenAiResponsesProvider().reviseSchedule(config, request, history)
-                else -> OpenAiCompatibleChatProvider().reviseSchedule(config, request, history)
+                    OpenAiResponsesProvider().reviseSchedule(config, request, history, networkContext)
+                else -> OpenAiCompatibleChatProvider().reviseSchedule(config, request, history, networkContext)
             }
             val revisedDraft = applyAiSchedulePatch(draft, result.content)
             AiScheduleImportResult(
@@ -1648,6 +1683,22 @@ class AiScheduleImportService(private val context: Context) {
         }
     }
 }
+
+private fun AiScheduleInput.networkContext(
+    inputType: String,
+    onHttpPhase: (AiImportHttpPhase) -> Unit,
+    screenshotCount: Int = 0
+): AiImportNetworkContext = AiImportNetworkContext(
+    inputType = inputType,
+    imageCount = when (this) {
+        is AiScheduleInput.ImageBase64 -> 1
+        is AiScheduleInput.Images -> images.size
+        is AiScheduleInput.CapturedPage -> images.size
+        else -> 0
+    },
+    screenshotCount = screenshotCount,
+    onPhase = onHttpPhase
+)
 
 suspend fun testAiProviderConnection(settings: AiImportSettings): Result<String> {
     return withContext(Dispatchers.IO) {
@@ -1915,7 +1966,11 @@ private fun PreprocessResult.toScheduleInput(file: AiImportFile): AiScheduleInpu
 }
 
 private interface AiScheduleImportProvider {
-    fun parseSchedule(config: AiProviderConfig, input: AiScheduleInput): AiProviderTextResult
+    fun parseSchedule(
+        config: AiProviderConfig,
+        input: AiScheduleInput,
+        networkContext: AiImportNetworkContext
+    ): AiProviderTextResult
 }
 
 private fun JsonObjectBuilder.putChatSamplingAndReasoning(config: AiProviderConfig) {
@@ -1938,7 +1993,11 @@ private fun JsonObjectBuilder.putChatSamplingAndReasoning(config: AiProviderConf
 }
 
 private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
-    override fun parseSchedule(config: AiProviderConfig, input: AiScheduleInput): AiProviderTextResult {
+    override fun parseSchedule(
+        config: AiProviderConfig,
+        input: AiScheduleInput,
+        networkContext: AiImportNetworkContext
+    ): AiProviderTextResult {
         val userContent: JsonElement = when (input) {
             is AiScheduleInput.ExtractedText -> JsonPrimitive(
                 aiSchedulePrompt() + "\n\n课表原文（${input.sourceName}）：\n" + input.text
@@ -1984,7 +2043,14 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
             putChatSamplingAndReasoning(config)
             putChatOutputBudget(config)
         }
-        val response = postJson(config.baseUrl.trimEnd('/') + "/chat/completions", config.apiKey, body.toString(), config.authType, config.providerId)
+        val response = postJson(
+            config.baseUrl.trimEnd('/') + "/chat/completions",
+            config.apiKey,
+            body.toString(),
+            config.authType,
+            config.providerId,
+            networkContext
+        )
         val result = runCatching {
             parseScheduleToolResult(response) ?: parseChatCompletionTextResult(response)
         }.getOrElse {
@@ -1992,7 +2058,12 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
             throw AiServiceResponseException("AI 响应结构无法解析：${it.message.orEmpty()}", response, it)
         }
         return if (result.finishReason == "length") {
-            continueTruncatedScheduleJson(config, body["messages"] ?: JsonArray(emptyList()), result)
+            continueTruncatedScheduleJson(
+                config,
+                body["messages"] ?: JsonArray(emptyList()),
+                result,
+                networkContext
+            )
         } else {
             result
         }
@@ -2001,7 +2072,8 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
     fun reviseSchedule(
         config: AiProviderConfig,
         request: String,
-        history: AiEduImportProgress
+        history: AiEduImportProgress,
+        networkContext: AiImportNetworkContext
     ): AiProviderTextResult {
         val initialMessages = buildJsonArray {
             scheduleParserSystemMessage()
@@ -2023,7 +2095,8 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
             config.apiKey,
             firstBody.toString(),
             config.authType,
-            config.providerId
+            config.providerId,
+            networkContext
         )
         parseSchedulePatchToolResult(firstResponse)?.let { return it }
         val root = Json.parseToJsonElement(firstResponse).jsonObject
@@ -2067,7 +2140,8 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
             config.apiKey,
             secondBody.toString(),
             config.authType,
-            config.providerId
+            config.providerId,
+            networkContext
         )
         return parseSchedulePatchToolResult(secondResponse)
             ?: throw AiServiceResponseException("模型读取原始材料后未提交课表", secondResponse)
@@ -2117,7 +2191,8 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
     private fun continueTruncatedScheduleJson(
         config: AiProviderConfig,
         originalMessages: JsonElement,
-        firstResult: AiProviderTextResult
+        firstResult: AiProviderTextResult,
+        networkContext: AiImportNetworkContext
     ): AiProviderTextResult {
         var combinedContent = firstResult.content
         var combinedReasoning = firstResult.reasoning
@@ -2151,7 +2226,14 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
                 putChatSamplingAndReasoning(config)
                 putChatOutputBudget(config)
             }
-            val response = postJson(config.baseUrl.trimEnd('/') + "/chat/completions", config.apiKey, body.toString(), config.authType, config.providerId)
+            val response = postJson(
+                config.baseUrl.trimEnd('/') + "/chat/completions",
+                config.apiKey,
+                body.toString(),
+                config.authType,
+                config.providerId,
+                networkContext
+            )
             val next = runCatching {
                 parseChatCompletionTextResult(response)
             }.getOrElse {
@@ -2172,7 +2254,11 @@ private class OpenAiCompatibleChatProvider : AiScheduleImportProvider {
 }
 
 private class OpenAiResponsesProvider : AiScheduleImportProvider {
-    override fun parseSchedule(config: AiProviderConfig, input: AiScheduleInput): AiProviderTextResult {
+    override fun parseSchedule(
+        config: AiProviderConfig,
+        input: AiScheduleInput,
+        networkContext: AiImportNetworkContext
+    ): AiProviderTextResult {
         val content = buildJsonArray {
             add(buildJsonObject {
                 put("type", JsonPrimitive("input_text"))
@@ -2250,7 +2336,8 @@ private class OpenAiResponsesProvider : AiScheduleImportProvider {
             config.apiKey,
             body.toString(),
             config.authType,
-            config.providerId
+            config.providerId,
+            networkContext
         )
         return parseScheduleToolResult(response) ?: parseResponsesTextResult(response)
     }
@@ -2258,7 +2345,8 @@ private class OpenAiResponsesProvider : AiScheduleImportProvider {
     fun reviseSchedule(
         config: AiProviderConfig,
         request: String,
-        history: AiEduImportProgress
+        history: AiEduImportProgress,
+        networkContext: AiImportNetworkContext
     ): AiProviderTextResult {
         val initialInput = buildJsonObject {
             put("role", JsonPrimitive("user"))
@@ -2283,7 +2371,8 @@ private class OpenAiResponsesProvider : AiScheduleImportProvider {
             config.apiKey,
             firstBody.toString(),
             config.authType,
-            config.providerId
+            config.providerId,
+            networkContext
         )
         parseSchedulePatchToolResult(firstResponse)?.let { return it }
         val root = Json.parseToJsonElement(firstResponse).jsonObject
@@ -2337,7 +2426,8 @@ private class OpenAiResponsesProvider : AiScheduleImportProvider {
             config.apiKey,
             secondBody.toString(),
             config.authType,
-            config.providerId
+            config.providerId,
+            networkContext
         )
         return parseSchedulePatchToolResult(secondResponse)
             ?: throw AiServiceResponseException("模型读取原始材料后未提交课表", secondResponse)
@@ -2603,6 +2693,67 @@ private fun request(url: String, apiKey: String, method: String, body: ByteArray
     }
 }
 
+private val AiImportRequestSequence = AtomicInteger()
+
+private class AiImportHttpTrace(
+    url: String,
+    private val providerId: String?,
+    private val endpointStyle: AiEndpointStyle,
+    private val requestContext: AiImportNetworkContext,
+    private val requestBodyBytes: Int
+) {
+    private val endpoint = URL(url)
+    private val startedAt = SystemClock.elapsedRealtime()
+    private val requestId = AiImportRequestSequence.incrementAndGet()
+        .toString(36)
+        .padStart(6, '0')
+    private var currentPhase = AiImportHttpPhase.REQUEST_CREATED
+
+    init {
+        logPhase(AiImportHttpPhase.REQUEST_CREATED)
+    }
+
+    fun mark(phase: AiImportHttpPhase) {
+        currentPhase = phase
+        logPhase(phase)
+        requestContext.onPhase(phase)
+    }
+
+    fun fail(error: Throwable) {
+        val cause = error.cause
+        Log.e(
+            AiImportLogTag,
+            commonFields() +
+                " phase=REQUEST_FAILED failedAt=${currentPhase.name}" +
+                " elapsedMs=${elapsedMs()}" +
+                " failure=${error.javaClass.name}" +
+                " message=${error.message.orEmpty().replace('\n', ' ').take(240)}" +
+                " cause=${cause?.javaClass?.name.orEmpty()}" +
+                " causeMessage=${cause?.message.orEmpty().replace('\n', ' ').take(240)}"
+        )
+    }
+
+    private fun logPhase(phase: AiImportHttpPhase) {
+        Log.d(
+            AiImportLogTag,
+            commonFields() + " phase=${phase.name} elapsedMs=${elapsedMs()}"
+        )
+    }
+
+    private fun commonFields(): String =
+        "request=$requestId" +
+            " provider=${providerId.orEmpty()}" +
+            " endpoint=${endpointStyle.name}" +
+            " host=${endpoint.host}" +
+            " path=${endpoint.path}" +
+            " input=${requestContext.inputType}" +
+            " bodyBytes=$requestBodyBytes" +
+            " images=${requestContext.imageCount}" +
+            " screenshots=${requestContext.screenshotCount}"
+
+    private fun elapsedMs(): Long = SystemClock.elapsedRealtime() - startedAt
+}
+
 private fun safeRequest(
     url: String,
     apiKey: String,
@@ -2610,32 +2761,38 @@ private fun safeRequest(
     body: ByteArray,
     contentType: String,
     authType: AiAuthType = AiAuthType.ApiKeyBearer,
-    providerId: String? = null
+    providerId: String? = null,
+    endpointStyle: AiEndpointStyle,
+    requestContext: AiImportNetworkContext
 ): String {
+    val trace = AiImportHttpTrace(url, providerId, endpointStyle, requestContext, body.size)
     val connection = (URL(url).openConnection() as HttpURLConnection).apply {
         requestMethod = method
         connectTimeout = 30_000
         readTimeout = 600_000
         doOutput = true
+        setFixedLengthStreamingMode(body.size.toLong())
         setAiAuthHeader(apiKey, authType)
         setRequestProperty("Content-Type", contentType)
         setRequestProperty("Accept", "application/json")
     }
     return try {
+        trace.mark(AiImportHttpPhase.BODY_WRITE_START)
         connection.outputStream.use { it.write(body) }
+        trace.mark(AiImportHttpPhase.BODY_WRITE_END)
         val status = connection.responseCode
-        val stream = if (status in 200..299) connection.inputStream else connection.errorStream
-        val text = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+        trace.mark(AiImportHttpPhase.HEADERS_RECEIVED)
         if (status !in 200..299) {
-            Log.d(AiImportLogTag, "AI HTTP $status url=${redactAiUrl(url)} response=${sanitizeAiOutputForDisplay(text).replace(Regex("\\s+"), " ").take(500)}")
+            val text = connection.errorStream?.bufferedReader()?.use { it.readText() }.orEmpty()
             throw AiServiceResponseException(formatAiRequestError(status, text, providerId), text)
         }
+        trace.mark(AiImportHttpPhase.BODY_READ_START)
+        val text = connection.inputStream.bufferedReader().use { it.readText() }
+        trace.mark(AiImportHttpPhase.STREAM_END)
         text
     } catch (throwable: Throwable) {
-        if (throwable is AiServiceResponseException) {
-            throw throwable
-        }
-        Log.d(AiImportLogTag, "AI network failure url=${redactAiUrl(url)} message=${throwable.message}", throwable)
+        trace.fail(throwable)
+        if (throwable is AiServiceResponseException) throw throwable
         throw IllegalStateException(formatAiNetworkError(url, throwable), throwable)
     } finally {
         connection.disconnect()
@@ -2725,23 +2882,26 @@ private fun postJson(
     apiKey: String,
     body: String,
     authType: AiAuthType = AiAuthType.ApiKeyBearer,
-    providerId: String? = null
+    providerId: String? = null,
+    requestContext: AiImportNetworkContext = AiImportNetworkContext("TEXT")
 ): String {
-    // Chat-completions requests stream instead of waiting for one silent blob: a steady
-    // byte flow keeps the connection alive while the app sits in the background, matching
-    // the Day Agent transport that already survives OEM background guards.
-    if (url.contains("/chat/completions")) {
-        return postChatCompletionStreaming(url, apiKey, body, authType, providerId)
+    return when {
+        url.contains("/chat/completions") ->
+            postChatCompletionStreaming(url, apiKey, body, authType, providerId, requestContext)
+        url.contains("/responses") ->
+            postResponsesStreaming(url, apiKey, body, authType, providerId, requestContext)
+        else -> safeRequest(
+            url,
+            apiKey,
+            "POST",
+            body.toByteArray(Charsets.UTF_8),
+            "application/json; charset=utf-8",
+            authType,
+            providerId,
+            AiEndpointStyle.KIMI_FILE_EXTRACT,
+            requestContext
+        )
     }
-    return safeRequest(
-        url,
-        apiKey,
-        "POST",
-        body.toByteArray(Charsets.UTF_8),
-        "application/json",
-        authType,
-        providerId
-    )
 }
 
 private fun postChatCompletionStreaming(
@@ -2749,7 +2909,8 @@ private fun postChatCompletionStreaming(
     apiKey: String,
     body: String,
     authType: AiAuthType = AiAuthType.ApiKeyBearer,
-    providerId: String? = null
+    providerId: String? = null,
+    requestContext: AiImportNetworkContext
 ): String {
     val streamedBody = runCatching {
         val jsonObject = Json.parseToJsonElement(body).jsonObject
@@ -2757,93 +2918,341 @@ private fun postChatCompletionStreaming(
         mutable["stream"] = JsonPrimitive(true)
         JsonObject(mutable).toString()
     }.getOrDefault(body)
+    val bodyBytes = streamedBody.toByteArray(Charsets.UTF_8)
+    val trace = AiImportHttpTrace(
+        url,
+        providerId,
+        AiEndpointStyle.CHAT_COMPLETIONS,
+        requestContext,
+        bodyBytes.size
+    )
     val connection = (URL(url).openConnection() as HttpURLConnection).apply {
         requestMethod = "POST"
         connectTimeout = 30_000
         readTimeout = 600_000
         doOutput = true
+        setFixedLengthStreamingMode(bodyBytes.size.toLong())
         setAiAuthHeader(apiKey, authType)
-        setRequestProperty("Content-Type", "application/json")
+        setRequestProperty("Content-Type", "application/json; charset=utf-8")
         setRequestProperty("Accept", "text/event-stream")
     }
     return try {
-        connection.outputStream.use { it.write(streamedBody.toByteArray(Charsets.UTF_8)) }
+        trace.mark(AiImportHttpPhase.BODY_WRITE_START)
+        connection.outputStream.use { it.write(bodyBytes) }
+        trace.mark(AiImportHttpPhase.BODY_WRITE_END)
         val status = connection.responseCode
-        val stream = if (status in 200..299) connection.inputStream else connection.errorStream
-        val text = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+        trace.mark(AiImportHttpPhase.HEADERS_RECEIVED)
         if (status !in 200..299) {
-            Log.d(
-                AiImportLogTag,
-                "AI HTTP $status url=${redactAiUrl(url)} response=${sanitizeAiOutputForDisplay(text).replace(Regex("\\s+"), " ").take(500)}"
-            )
+            val text = connection.errorStream?.bufferedReader()?.use { it.readText() }.orEmpty()
             throw AiServiceResponseException(formatAiRequestError(status, text, providerId), text)
         }
-        assembleChatCompletionFromSse(text)
-    } catch (throwable: Throwable) {
-        if (throwable is AiServiceResponseException) {
-            throw throwable
+        if (!connection.contentType.orEmpty().contains("text/event-stream", ignoreCase = true)) {
+            trace.mark(AiImportHttpPhase.BODY_READ_START)
+            connection.inputStream.bufferedReader().use { it.readText() }
+                .also { trace.mark(AiImportHttpPhase.STREAM_END) }
+        } else {
+            val accumulator = ChatCompletionSseAccumulator()
+            var firstEvent = true
+            BufferedReader(InputStreamReader(connection.inputStream, Charsets.UTF_8)).useLines { lines ->
+                lines.forEach { line ->
+                    if (!line.startsWith("data:")) return@forEach
+                    val payload = line.removePrefix("data:").trim()
+                    if (payload.isBlank() || payload == "[DONE]") return@forEach
+                    if (firstEvent) {
+                        firstEvent = false
+                        trace.mark(AiImportHttpPhase.FIRST_EVENT)
+                    }
+                    accumulator.consume(payload)
+                }
+            }
+            trace.mark(AiImportHttpPhase.STREAM_END)
+            accumulator.toCompletionJson()
         }
-        Log.d(AiImportLogTag, "AI network failure (stream) url=${redactAiUrl(url)} message=${throwable.message}", throwable)
+    } catch (throwable: Throwable) {
+        trace.fail(throwable)
+        if (throwable is AiServiceResponseException) throw throwable
         throw IllegalStateException(formatAiNetworkError(url, throwable), throwable)
     } finally {
         connection.disconnect()
     }
 }
 
-/**
- * Aggregates an OpenAI-compatible `chat/completions` SSE stream back into the plain
- * completion JSON the non-streaming parser expects, so every caller keeps working.
- */
-private fun assembleChatCompletionFromSse(raw: String): String {
+private fun postResponsesStreaming(
+    url: String,
+    apiKey: String,
+    body: String,
+    authType: AiAuthType,
+    providerId: String?,
+    requestContext: AiImportNetworkContext
+): String {
+    val streamedBody = runCatching {
+        val values = Json.parseToJsonElement(body).jsonObject.toMutableMap()
+        values["stream"] = JsonPrimitive(true)
+        JsonObject(values).toString()
+    }.getOrDefault(body)
+    val bodyBytes = streamedBody.toByteArray(Charsets.UTF_8)
+    val trace = AiImportHttpTrace(
+        url,
+        providerId,
+        AiEndpointStyle.RESPONSES,
+        requestContext,
+        bodyBytes.size
+    )
+    val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+        requestMethod = "POST"
+        connectTimeout = 30_000
+        readTimeout = 600_000
+        doOutput = true
+        setFixedLengthStreamingMode(bodyBytes.size.toLong())
+        setAiAuthHeader(apiKey, authType)
+        setRequestProperty("Content-Type", "application/json; charset=utf-8")
+        setRequestProperty("Accept", "text/event-stream")
+    }
+    return try {
+        trace.mark(AiImportHttpPhase.BODY_WRITE_START)
+        connection.outputStream.use { it.write(bodyBytes) }
+        trace.mark(AiImportHttpPhase.BODY_WRITE_END)
+        val status = connection.responseCode
+        trace.mark(AiImportHttpPhase.HEADERS_RECEIVED)
+        if (status !in 200..299) {
+            val text = connection.errorStream?.bufferedReader()?.use { it.readText() }.orEmpty()
+            throw AiServiceResponseException(formatAiRequestError(status, text, providerId), text)
+        }
+        if (!connection.contentType.orEmpty().contains("text/event-stream", ignoreCase = true)) {
+            trace.mark(AiImportHttpPhase.BODY_READ_START)
+            connection.inputStream.bufferedReader().use { it.readText() }
+                .also { trace.mark(AiImportHttpPhase.STREAM_END) }
+        } else {
+            val accumulator = ResponsesSseAccumulator()
+            var firstEvent = true
+            BufferedReader(InputStreamReader(connection.inputStream, Charsets.UTF_8)).useLines { lines ->
+                lines.forEach { line ->
+                    if (!line.startsWith("data:")) return@forEach
+                    val payload = line.removePrefix("data:").trim()
+                    if (payload.isBlank() || payload == "[DONE]") return@forEach
+                    if (firstEvent) {
+                        firstEvent = false
+                        trace.mark(AiImportHttpPhase.FIRST_EVENT)
+                    }
+                    accumulator.consume(payload)
+                }
+            }
+            trace.mark(AiImportHttpPhase.STREAM_END)
+            accumulator.toResponseJson()
+        }
+    } catch (throwable: Throwable) {
+        trace.fail(throwable)
+        if (throwable is AiServiceResponseException) throw throwable
+        throw IllegalStateException(formatAiNetworkError(url, throwable), throwable)
+    } finally {
+        connection.disconnect()
+    }
+}
+
+private class ChatCompletionSseAccumulator {
     val content = StringBuilder()
     val reasoning = StringBuilder()
     var finishReason = ""
     var sawChunk = false
-    raw.lineSequence().forEach { line ->
-        val trimmed = line.trim()
-        if (!trimmed.startsWith("data:")) return@forEach
-        val payload = trimmed.removePrefix("data:").trim()
-        if (payload.isEmpty() || payload == "[DONE]") return@forEach
-        val chunk = runCatching { Json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return@forEach
+    private var fullMessage: JsonObject? = null
+    private val toolCalls = linkedMapOf<Int, ChatToolCallAccumulator>()
+
+    fun consume(payload: String) {
+        val chunk = runCatching { Json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return
         sawChunk = true
-        val choice = chunk["choices"]?.jsonArray?.firstOrNull()?.jsonObject ?: return@forEach
+        val choice = chunk["choices"]?.jsonArray?.firstOrNull()?.jsonObject ?: return
         val delta = choice["delta"]?.jsonObject
         if (delta != null) {
-            delta["content"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotEmpty() }?.let { content.append(it) }
+            runCatching { delta["content"]?.jsonPrimitive?.contentOrNull }
+                .getOrNull()?.takeIf { it.isNotEmpty() }?.let(content::append)
             listOf("reasoning_content", "reasoning").forEach { key ->
                 delta[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotEmpty() }?.let { reasoning.append(it) }
             }
-        } else {
-            // Some providers end the stream with a full message instead of a delta.
-            choice["message"]?.jsonObject?.let { message ->
-                message["content"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let {
-                    content.clear()
-                    content.append(it)
-                }
+            delta["tool_calls"]?.jsonArray.orEmpty().forEachIndexed { fallbackIndex, rawCall ->
+                val call = rawCall.jsonObject
+                val index = call["index"]?.jsonPrimitive?.intOrNull ?: fallbackIndex
+                toolCalls.getOrPut(index, ::ChatToolCallAccumulator).consume(call)
             }
+            delta["function_call"]?.jsonObject?.let { function ->
+                toolCalls.getOrPut(0, ::ChatToolCallAccumulator).consumeFunction(function)
+            }
+        } else {
+            choice["message"]?.jsonObject?.let { fullMessage = it }
         }
         choice["finish_reason"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let { finishReason = it }
     }
-    if (!sawChunk) {
-        if (raw.trimStart().startsWith("{")) {
-            // The provider ignored stream=true and answered with a plain completion.
-            return raw
-        }
-        throw AiServiceResponseException("AI 流式响应里没有收到任何内容。", raw)
-    }
-    return buildJsonObject {
+
+    fun toCompletionJson(): String {
+        if (!sawChunk) throw AiServiceResponseException("AI 流式响应里没有收到任何内容。", "")
+        return buildJsonObject {
         put("choices", buildJsonArray {
             add(buildJsonObject {
-                put("message", buildJsonObject {
+                put("message", fullMessage ?: buildJsonObject {
+                    put("role", JsonPrimitive("assistant"))
                     put("content", JsonPrimitive(content.toString()))
-                    if (reasoning.isNotBlank()) {
+                    if (reasoning.isNotEmpty()) {
                         put("reasoning_content", JsonPrimitive(reasoning.toString()))
+                    }
+                    if (toolCalls.isNotEmpty()) {
+                        put("tool_calls", buildJsonArray {
+                            toolCalls.toSortedMap().values.forEach { add(it.toJson()) }
+                        })
                     }
                 })
                 put("finish_reason", JsonPrimitive(finishReason.ifBlank { "stop" }))
             })
         })
-    }.toString()
+        }.toString()
+    }
+}
+
+private class ChatToolCallAccumulator {
+    private var id = ""
+    private var type = "function"
+    private val name = StringBuilder()
+    private val arguments = StringBuilder()
+
+    fun consume(call: JsonObject) {
+        call["id"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)?.let { id = it }
+        call["type"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotBlank)?.let { type = it }
+        call["function"]?.jsonObject?.let(::consumeFunction)
+    }
+
+    fun consumeFunction(function: JsonObject) {
+        function["name"]?.jsonPrimitive?.contentOrNull?.let(name::append)
+        function["arguments"]?.jsonPrimitive?.contentOrNull?.let(arguments::append)
+    }
+
+    fun toJson(): JsonObject = buildJsonObject {
+        put("id", JsonPrimitive(id.ifBlank { "call_sleepdown" }))
+        put("type", JsonPrimitive(type))
+        put("function", buildJsonObject {
+            put("name", JsonPrimitive(name.toString()))
+            put("arguments", JsonPrimitive(arguments.toString()))
+        })
+    }
+}
+
+private class ResponsesSseAccumulator {
+    private var completedResponse: JsonObject? = null
+    private val outputItems = linkedMapOf<String, JsonObject>()
+    private val functionCalls = linkedMapOf<String, ResponsesFunctionCallAccumulator>()
+    private val outputText = StringBuilder()
+    private val reasoning = StringBuilder()
+    private var sawEvent = false
+
+    fun consume(payload: String) {
+        val event = runCatching { Json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return
+        sawEvent = true
+        when (event["type"]?.jsonPrimitive?.contentOrNull.orEmpty()) {
+            "response.completed" -> completedResponse = event["response"]?.jsonObject
+            "response.output_item.added", "response.output_item.done" -> {
+                val item = event["item"]?.jsonObject ?: return
+                val key = item["id"]?.jsonPrimitive?.contentOrNull
+                    ?: event["output_index"]?.jsonPrimitive?.intOrNull?.toString()
+                    ?: outputItems.size.toString()
+                outputItems[key] = item
+                if (item["type"]?.jsonPrimitive?.contentOrNull == "function_call") {
+                    functionCalls.getOrPut(key, ::ResponsesFunctionCallAccumulator).seed(item)
+                }
+            }
+            "response.function_call_arguments.delta" -> {
+                val key = event["item_id"]?.jsonPrimitive?.contentOrNull
+                    ?: event["output_index"]?.jsonPrimitive?.intOrNull?.toString()
+                    ?: "0"
+                functionCalls.getOrPut(key, ::ResponsesFunctionCallAccumulator)
+                    .append(event["delta"]?.jsonPrimitive?.contentOrNull.orEmpty())
+            }
+            "response.function_call_arguments.done" -> {
+                val key = event["item_id"]?.jsonPrimitive?.contentOrNull
+                    ?: event["output_index"]?.jsonPrimitive?.intOrNull?.toString()
+                    ?: "0"
+                functionCalls.getOrPut(key, ::ResponsesFunctionCallAccumulator)
+                    .finish(event["arguments"]?.jsonPrimitive?.contentOrNull.orEmpty())
+            }
+            "response.output_text.delta" ->
+                event["delta"]?.jsonPrimitive?.contentOrNull?.let(outputText::append)
+            "response.reasoning_summary_text.delta", "response.reasoning_text.delta" ->
+                event["delta"]?.jsonPrimitive?.contentOrNull?.let(reasoning::append)
+            "response.failed", "error" -> {
+                val detail = event["error"]?.jsonObject?.get("message")
+                    ?.jsonPrimitive?.contentOrNull.orEmpty()
+                throw AiServiceResponseException(detail.ifBlank { "AI Responses 流式请求失败。" }, payload)
+            }
+        }
+    }
+
+    fun toResponseJson(): String {
+        completedResponse?.let { return it.toString() }
+        if (!sawEvent) throw AiServiceResponseException("AI Responses 流式响应里没有收到任何事件。", "")
+        val functionKeys = functionCalls.keys
+        val items = outputItems.filterKeys { it !in functionKeys }.values.toMutableList()
+        items += functionCalls.values.map(ResponsesFunctionCallAccumulator::toJson)
+        if (reasoning.isNotEmpty()) {
+            items += buildJsonObject {
+                put("type", JsonPrimitive("reasoning"))
+                put("summary", buildJsonArray {
+                    add(buildJsonObject {
+                        put("type", JsonPrimitive("summary_text"))
+                        put("text", JsonPrimitive(reasoning.toString()))
+                    })
+                })
+            }
+        }
+        if (outputText.isNotEmpty()) {
+            items += buildJsonObject {
+                put("type", JsonPrimitive("message"))
+                put("role", JsonPrimitive("assistant"))
+                put("content", buildJsonArray {
+                    add(buildJsonObject {
+                        put("type", JsonPrimitive("output_text"))
+                        put("text", JsonPrimitive(outputText.toString()))
+                    })
+                })
+            }
+        }
+        return buildJsonObject {
+            put("status", JsonPrimitive("completed"))
+            put("output", JsonArray(items))
+            if (outputText.isNotEmpty()) put("output_text", JsonPrimitive(outputText.toString()))
+        }.toString()
+    }
+}
+
+private class ResponsesFunctionCallAccumulator {
+    private var id = ""
+    private var callId = ""
+    private var name = ""
+    private val arguments = StringBuilder()
+
+    fun seed(item: JsonObject) {
+        id = item["id"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        callId = item["call_id"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        name = item["name"]?.jsonPrimitive?.contentOrNull.orEmpty()
+        item["arguments"]?.jsonPrimitive?.contentOrNull?.takeIf(String::isNotEmpty)?.let {
+            arguments.clear()
+            arguments.append(it)
+        }
+    }
+
+    fun append(delta: String) {
+        arguments.append(delta)
+    }
+
+    fun finish(value: String) {
+        if (value.isNotEmpty()) {
+            arguments.clear()
+            arguments.append(value)
+        }
+    }
+
+    fun toJson(): JsonObject = buildJsonObject {
+        put("type", JsonPrimitive("function_call"))
+        if (id.isNotBlank()) put("id", JsonPrimitive(id))
+        put("call_id", JsonPrimitive(callId.ifBlank { id.ifBlank { "call_sleepdown" } }))
+        put("name", JsonPrimitive(name))
+        put("arguments", JsonPrimitive(arguments.toString()))
+    }
 }
 
 private fun parseChatCompletionTextResult(response: String, requireContent: Boolean = true): AiProviderTextResult {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImport.kt
@@ -2727,6 +2727,12 @@ private fun postJson(
     authType: AiAuthType = AiAuthType.ApiKeyBearer,
     providerId: String? = null
 ): String {
+    // Chat-completions requests stream instead of waiting for one silent blob: a steady
+    // byte flow keeps the connection alive while the app sits in the background, matching
+    // the Day Agent transport that already survives OEM background guards.
+    if (url.contains("/chat/completions")) {
+        return postChatCompletionStreaming(url, apiKey, body, authType, providerId)
+    }
     return safeRequest(
         url,
         apiKey,
@@ -2736,6 +2742,108 @@ private fun postJson(
         authType,
         providerId
     )
+}
+
+private fun postChatCompletionStreaming(
+    url: String,
+    apiKey: String,
+    body: String,
+    authType: AiAuthType = AiAuthType.ApiKeyBearer,
+    providerId: String? = null
+): String {
+    val streamedBody = runCatching {
+        val jsonObject = Json.parseToJsonElement(body).jsonObject
+        val mutable = jsonObject.toMutableMap()
+        mutable["stream"] = JsonPrimitive(true)
+        JsonObject(mutable).toString()
+    }.getOrDefault(body)
+    val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+        requestMethod = "POST"
+        connectTimeout = 30_000
+        readTimeout = 600_000
+        doOutput = true
+        setAiAuthHeader(apiKey, authType)
+        setRequestProperty("Content-Type", "application/json")
+        setRequestProperty("Accept", "text/event-stream")
+    }
+    return try {
+        connection.outputStream.use { it.write(streamedBody.toByteArray(Charsets.UTF_8)) }
+        val status = connection.responseCode
+        val stream = if (status in 200..299) connection.inputStream else connection.errorStream
+        val text = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+        if (status !in 200..299) {
+            Log.d(
+                AiImportLogTag,
+                "AI HTTP $status url=${redactAiUrl(url)} response=${sanitizeAiOutputForDisplay(text).replace(Regex("\\s+"), " ").take(500)}"
+            )
+            throw AiServiceResponseException(formatAiRequestError(status, text, providerId), text)
+        }
+        assembleChatCompletionFromSse(text)
+    } catch (throwable: Throwable) {
+        if (throwable is AiServiceResponseException) {
+            throw throwable
+        }
+        Log.d(AiImportLogTag, "AI network failure (stream) url=${redactAiUrl(url)} message=${throwable.message}", throwable)
+        throw IllegalStateException(formatAiNetworkError(url, throwable), throwable)
+    } finally {
+        connection.disconnect()
+    }
+}
+
+/**
+ * Aggregates an OpenAI-compatible `chat/completions` SSE stream back into the plain
+ * completion JSON the non-streaming parser expects, so every caller keeps working.
+ */
+private fun assembleChatCompletionFromSse(raw: String): String {
+    val content = StringBuilder()
+    val reasoning = StringBuilder()
+    var finishReason = ""
+    var sawChunk = false
+    raw.lineSequence().forEach { line ->
+        val trimmed = line.trim()
+        if (!trimmed.startsWith("data:")) return@forEach
+        val payload = trimmed.removePrefix("data:").trim()
+        if (payload.isEmpty() || payload == "[DONE]") return@forEach
+        val chunk = runCatching { Json.parseToJsonElement(payload).jsonObject }.getOrNull() ?: return@forEach
+        sawChunk = true
+        val choice = chunk["choices"]?.jsonArray?.firstOrNull()?.jsonObject ?: return@forEach
+        val delta = choice["delta"]?.jsonObject
+        if (delta != null) {
+            delta["content"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotEmpty() }?.let { content.append(it) }
+            listOf("reasoning_content", "reasoning").forEach { key ->
+                delta[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotEmpty() }?.let { reasoning.append(it) }
+            }
+        } else {
+            // Some providers end the stream with a full message instead of a delta.
+            choice["message"]?.jsonObject?.let { message ->
+                message["content"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let {
+                    content.clear()
+                    content.append(it)
+                }
+            }
+        }
+        choice["finish_reason"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() }?.let { finishReason = it }
+    }
+    if (!sawChunk) {
+        if (raw.trimStart().startsWith("{")) {
+            // The provider ignored stream=true and answered with a plain completion.
+            return raw
+        }
+        throw AiServiceResponseException("AI 流式响应里没有收到任何内容。", raw)
+    }
+    return buildJsonObject {
+        put("choices", buildJsonArray {
+            add(buildJsonObject {
+                put("message", buildJsonObject {
+                    put("content", JsonPrimitive(content.toString()))
+                    if (reasoning.isNotBlank()) {
+                        put("reasoning_content", JsonPrimitive(reasoning.toString()))
+                    }
+                })
+                put("finish_reason", JsonPrimitive(finishReason.ifBlank { "stop" }))
+            })
+        })
+    }.toString()
 }
 
 private fun parseChatCompletionTextResult(response: String, requireContent: Boolean = true): AiProviderTextResult {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
@@ -1,0 +1,220 @@
+package com.xiaomanjun.sleepdownschedule.feature.importing
+
+import com.xiaomanjun.sleepdownschedule.AiImportForegroundService
+import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
+import com.xiaomanjun.sleepdownschedule.model.ImportDraftSource
+
+import android.content.Context
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+/** Owns the single active AI import after the user has confirmed sending its input. */
+object AiImportTaskManager {
+    const val EXTRA_TASK_ID = "ai_import_task_id"
+
+    private val taskScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var activeJob: Job? = null
+
+    fun startFileImport(
+        context: Context,
+        file: AiImportFile,
+        settings: AiImportSettings,
+        scheduleConfig: ScheduleConfigEntity,
+        initialProgress: AiEduImportProgress
+    ): String = startTask(context, initialProgress, scheduleConfig) { onRequestStarted ->
+        AiScheduleImportService(context.applicationContext).parseScheduleFile(
+            file = file,
+            settings = settings,
+            onRequestStarted = onRequestStarted
+        )
+    }
+
+    fun startTextImport(
+        context: Context,
+        text: String,
+        sourceName: String,
+        settings: AiImportSettings,
+        scheduleConfig: ScheduleConfigEntity,
+        initialProgress: AiEduImportProgress
+    ): String = startTask(context, initialProgress, scheduleConfig) { onRequestStarted ->
+        AiScheduleImportService(context.applicationContext).parseScheduleText(
+            text = text,
+            sourceName = sourceName,
+            settings = settings,
+            onRequestStarted = onRequestStarted
+        )
+    }
+
+    fun startCapturedPageImport(
+        context: Context,
+        text: String,
+        screenshots: List<RenderedPageImage>,
+        sourceName: String,
+        warnings: List<String>,
+        settings: AiImportSettings,
+        scheduleConfig: ScheduleConfigEntity,
+        initialProgress: AiEduImportProgress
+    ): String = startTask(context, initialProgress, scheduleConfig) { onRequestStarted ->
+        AiScheduleImportService(context.applicationContext).parseScheduleCapturedPage(
+            text = text,
+            screenshots = screenshots,
+            sourceName = sourceName,
+            warnings = warnings,
+            settings = settings,
+            onRequestStarted = onRequestStarted
+        )
+    }
+
+    private fun startTask(
+        context: Context,
+        initialProgress: AiEduImportProgress,
+        scheduleConfig: ScheduleConfigEntity,
+        request: suspend (() -> Unit) -> Result<AiScheduleImportResult>
+    ): String {
+        val appContext = context.applicationContext
+        val taskId = UUID.randomUUID().toString()
+        activeJob?.cancel()
+        AiEduImportProgressSession.setPreviewDraft(null)
+        AiEduImportProgressSession.update(
+            initialProgress.copy(
+                taskId = taskId,
+                awaitingConfirmation = false,
+                confirmActionLabel = "",
+                secondaryConfirmActionLabel = "",
+                screenModeActionLabel = "",
+                cancelActionLabel = "",
+                requestSent = false,
+                finished = false,
+                error = null
+            )
+        )
+        AiImportForegroundService.start(appContext, taskId, "正在整理输入")
+        activeJob = taskScope.launch {
+            try {
+                runTask(appContext, taskId, scheduleConfig, request)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
+                finishFailure(appContext, taskId, error, "AI 导入任务未完成")
+            }
+        }
+        return taskId
+    }
+
+    private suspend fun runTask(
+        context: Context,
+        taskId: String,
+        scheduleConfig: ScheduleConfigEntity,
+        request: suspend (() -> Unit) -> Result<AiScheduleImportResult>
+    ) = coroutineScope {
+        appendMainStep(taskId, context, "正在整理输入", "正在整理课程材料，准备发送给 AI。")
+        var summaryTicker: Job? = null
+        val result = request {
+            appendMainStep(taskId, context, "已发送给 AI", "材料已发送，正在等待模型开始解析。")
+            appendMainStep(taskId, context, "AI 正在解析课程", "正在识别课程结构。")
+            summaryTicker = launch {
+                listOf(
+                    "正在整理课程名称与教师",
+                    "正在核对星期和节次",
+                    "正在检查周次范围",
+                    "正在等待模型返回完整结果"
+                ).forEach { summary ->
+                    delay(2_600)
+                    if (isActive) updateMicroStatus(taskId, summary)
+                }
+            }
+        }
+        summaryTicker?.cancel()
+        val aiResult = result.getOrElse { error ->
+            finishFailure(context, taskId, error, "AI 请求失败")
+            return@coroutineScope
+        }
+        update(taskId) {
+            it.copy(
+                reasoningOutput = aiResult.reasoningOutput,
+                aiOutput = aiResult.rawOutput
+            )
+        }
+        appendMainStep(taskId, context, "正在校验课程数据", "正在检查星期、节次、周次和重复课程。")
+        val parsed = ScheduleImportParser.parse(
+            aiResult.output.ifBlank { aiResult.rawOutput },
+            scheduleConfig
+        ).getOrElse { error ->
+            finishFailure(context, taskId, error, "课程数据校验失败")
+            return@coroutineScope
+        }
+        appendMainStep(taskId, context, "正在生成导入预览", "课程数据已通过校验，正在整理导入预览。")
+        val preview = parsed.copy(source = ImportDraftSource.AI_EDU)
+        AiEduImportProgressSession.setPreviewDraft(preview)
+        val completed = update(taskId) {
+            it.copy(
+                steps = it.steps + "完成",
+                liveSummary = "已整理出 ${preview.courses.size} 门课程，可以检查导入预览。",
+                requestSent = true,
+                finished = true,
+                error = null
+            )
+        }
+        AiImportHistoryStore.record(context, preview, completed)
+        AiImportForegroundService.complete(context, taskId, preview.courses.size)
+    }
+
+    private fun appendMainStep(
+        taskId: String,
+        context: Context,
+        step: String,
+        summary: String
+    ) {
+        update(taskId) { progress ->
+            progress.copy(
+                steps = if (progress.steps.lastOrNull() == step) progress.steps else progress.steps + step,
+                liveSummary = summary,
+                requestSent = progress.requestSent || step == "已发送给 AI" || step == "AI 正在解析课程"
+            )
+        }
+        AiImportForegroundService.update(context, taskId, step)
+    }
+
+    private fun updateMicroStatus(taskId: String, summary: String) {
+        update(taskId) { progress -> progress.copy(liveSummary = summary) }
+    }
+
+    private fun finishFailure(
+        context: Context,
+        taskId: String,
+        error: Throwable,
+        step: String
+    ) {
+        val rawBody = error.aiRawResponseBody().orEmpty()
+        update(taskId) { progress ->
+            progress.copy(
+                steps = progress.steps + step,
+                liveSummary = error.message ?: step,
+                reasoningOutput = extractAiReasoningForDisplay(rawBody).ifBlank { progress.reasoningOutput },
+                aiOutput = sanitizeAiOutputForDisplay(rawBody).ifBlank { progress.aiOutput },
+                requestSent = progress.requestSent,
+                error = error.message ?: step,
+                finished = true
+            )
+        }
+        AiImportForegroundService.fail(context, taskId, error.message ?: step)
+    }
+
+    private fun update(
+        taskId: String,
+        transform: (AiEduImportProgress) -> AiEduImportProgress
+    ): AiEduImportProgress? {
+        val current = AiEduImportProgressSession.progress.value
+            ?.takeIf { it.taskId == taskId }
+            ?: return null
+        return transform(current).copy(taskId = taskId).also(AiEduImportProgressSession::update)
+    }
+}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
@@ -31,11 +31,11 @@ object AiImportTaskManager {
         settings: AiImportSettings,
         scheduleConfig: ScheduleConfigEntity,
         initialProgress: AiEduImportProgress
-    ): String = startTask(context, initialProgress, scheduleConfig) { onRequestStarted ->
+    ): String = startTask(context, initialProgress, scheduleConfig) { onHttpPhase ->
         AiScheduleImportService(context.applicationContext).parseScheduleFile(
             file = file,
             settings = settings,
-            onRequestStarted = onRequestStarted
+            onHttpPhase = onHttpPhase
         )
     }
 
@@ -46,12 +46,12 @@ object AiImportTaskManager {
         settings: AiImportSettings,
         scheduleConfig: ScheduleConfigEntity,
         initialProgress: AiEduImportProgress
-    ): String = startTask(context, initialProgress, scheduleConfig) { onRequestStarted ->
+    ): String = startTask(context, initialProgress, scheduleConfig) { onHttpPhase ->
         AiScheduleImportService(context.applicationContext).parseScheduleText(
             text = text,
             sourceName = sourceName,
             settings = settings,
-            onRequestStarted = onRequestStarted
+            onHttpPhase = onHttpPhase
         )
     }
 
@@ -64,14 +64,14 @@ object AiImportTaskManager {
         settings: AiImportSettings,
         scheduleConfig: ScheduleConfigEntity,
         initialProgress: AiEduImportProgress
-    ): String = startTask(context, initialProgress, scheduleConfig) { onRequestStarted ->
+    ): String = startTask(context, initialProgress, scheduleConfig) { onHttpPhase ->
         AiScheduleImportService(context.applicationContext).parseScheduleCapturedPage(
             text = text,
             screenshots = screenshots,
             sourceName = sourceName,
             warnings = warnings,
             settings = settings,
-            onRequestStarted = onRequestStarted
+            onHttpPhase = onHttpPhase
         )
     }
 
@@ -89,10 +89,10 @@ object AiImportTaskManager {
         AiEduImportProgressSession.update(
             baseProgress.copy(
                 taskId = taskId,
-                steps = baseProgress.steps + "正在理解你的修改要求",
+                steps = baseProgress.steps + "正在整理输入",
                 userPrompt = instruction,
-                liveSummary = "正在理解你的修改要求，并核对现有课程、周次和节次。",
-                requestSent = true,
+                liveSummary = "正在整理修改要求、现有课程和原始材料。",
+                requestSent = false,
                 finished = false,
                 error = null
             )
@@ -115,7 +115,7 @@ object AiImportTaskManager {
                 finishFailure(appContext, taskId, error, "AI 修改任务未完成")
             }
         }
-        AiImportForegroundService.start(appContext, taskId, "正在理解修改要求")
+        AiImportForegroundService.start(appContext, taskId, "正在整理输入")
         return taskId
     }
 
@@ -123,7 +123,7 @@ object AiImportTaskManager {
         context: Context,
         initialProgress: AiEduImportProgress,
         scheduleConfig: ScheduleConfigEntity,
-        request: suspend (() -> Unit) -> Result<AiScheduleImportResult>
+        request: suspend ((AiImportHttpPhase) -> Unit) -> Result<AiScheduleImportResult>
     ): String {
         val appContext = context.applicationContext
         val taskId = UUID.randomUUID().toString()
@@ -193,23 +193,34 @@ object AiImportTaskManager {
         context: Context,
         taskId: String,
         scheduleConfig: ScheduleConfigEntity,
-        request: suspend (() -> Unit) -> Result<AiScheduleImportResult>
+        request: suspend ((AiImportHttpPhase) -> Unit) -> Result<AiScheduleImportResult>
     ) = coroutineScope {
         appendMainStep(taskId, context, "正在整理输入", "正在整理课程材料，准备发送给 AI。")
         var summaryTicker: Job? = null
-        val result = request {
-            appendMainStep(taskId, context, "已发送给 AI", "材料已发送，正在等待模型开始解析。")
-            appendMainStep(taskId, context, "AI 正在解析课程", "正在识别课程结构。")
-            summaryTicker = launch {
-                listOf(
-                    "正在整理课程名称与教师",
-                    "正在核对星期和节次",
-                    "正在检查周次范围",
-                    "正在等待模型返回完整结果"
-                ).forEach { summary ->
-                    delay(2_600)
-                    if (isActive) updateMicroStatus(taskId, summary)
+        val result = request { phase ->
+            when (phase) {
+                AiImportHttpPhase.BODY_WRITE_START ->
+                    appendMainStep(taskId, context, "正在上传材料", "正在上传课表材料。")
+                AiImportHttpPhase.BODY_WRITE_END ->
+                    appendMainStep(taskId, context, "已发送给 AI", "材料已发送，正在等待模型响应。")
+                AiImportHttpPhase.FIRST_EVENT,
+                AiImportHttpPhase.BODY_READ_START -> {
+                    appendMainStep(taskId, context, "AI 正在解析课程", "正在识别课程结构。")
+                    if (summaryTicker == null) {
+                        summaryTicker = launch {
+                            listOf(
+                                "正在整理课程名称与教师",
+                                "正在核对星期和节次",
+                                "正在检查周次范围",
+                                "正在等待模型返回完整结果"
+                            ).forEach { summary ->
+                                delay(2_600)
+                                if (isActive) updateMicroStatus(taskId, summary)
+                            }
+                        }
+                    }
                 }
+                else -> Unit
             }
         }
         summaryTicker?.cancel()
@@ -256,25 +267,41 @@ object AiImportTaskManager {
         settings: AiImportSettings,
         historicalEntryId: String?
     ) = coroutineScope {
-        appendMainStep(taskId, context, "AI 正在修改课程", "正在核对现有课表结构并生成修改方案。")
-        val summaryTicker = launch {
-            listOf(
-                "正在核对课程、周次和节次",
-                "正在生成课程修改方案",
-                "正在等待模型返回完整结果"
-            ).forEach { summary ->
-                delay(2_600)
-                if (isActive) updateMicroStatus(taskId, summary)
+        appendMainStep(taskId, context, "正在整理输入", "正在整理修改要求、现有课程和原始材料。")
+        var summaryTicker: Job? = null
+        val onHttpPhase: (AiImportHttpPhase) -> Unit = { phase ->
+            when (phase) {
+                AiImportHttpPhase.BODY_WRITE_START ->
+                    appendMainStep(taskId, context, "正在上传材料", "正在上传修改要求和课表材料。")
+                AiImportHttpPhase.BODY_WRITE_END ->
+                    appendMainStep(taskId, context, "已发送给 AI", "修改材料已发送，正在等待模型响应。")
+                AiImportHttpPhase.FIRST_EVENT,
+                AiImportHttpPhase.BODY_READ_START -> {
+                    appendMainStep(taskId, context, "AI 正在解析课程", "正在核对现有课表并生成修改方案。")
+                    if (summaryTicker == null) {
+                        summaryTicker = launch {
+                            listOf(
+                                "正在核对课程、周次和节次",
+                                "正在生成课程修改方案",
+                                "正在等待模型返回完整结果"
+                            ).forEach { summary ->
+                                delay(2_600)
+                                if (isActive) updateMicroStatus(taskId, summary)
+                            }
+                        }
+                    }
+                }
+                else -> Unit
             }
         }
         val result = AiScheduleImportService(context)
-            .reviseSchedule(baseDraft, instruction, baseProgress, settings)
+            .reviseSchedule(baseDraft, instruction, baseProgress, settings, onHttpPhase)
             .getOrElse { error ->
-                summaryTicker.cancel()
+                summaryTicker?.cancel()
                 finishFailure(context, taskId, error, "AI 修改请求失败")
                 return@coroutineScope
             }
-        summaryTicker.cancel()
+        summaryTicker?.cancel()
         update(taskId) {
             it.copy(reasoningOutput = result.reasoningOutput, aiOutput = result.rawOutput)
         }
@@ -334,7 +361,7 @@ object AiImportTaskManager {
     ) {
         update(taskId) { progress ->
             progress.copy(
-                steps = if (progress.steps.lastOrNull() == step) progress.steps else progress.steps + step,
+                steps = if (step in progress.steps) progress.steps else progress.steps + step,
                 liveSummary = summary,
                 requestSent = progress.requestSent || step == "已发送给 AI" || step == "AI 正在解析课程"
             )

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
@@ -2,6 +2,7 @@ package com.xiaomanjun.sleepdownschedule.feature.importing
 
 import com.xiaomanjun.sleepdownschedule.AiImportForegroundService
 import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
+import com.xiaomanjun.sleepdownschedule.model.ImportDraft
 import com.xiaomanjun.sleepdownschedule.model.ImportDraftSource
 
 import android.content.Context
@@ -71,6 +72,50 @@ object AiImportTaskManager {
             settings = settings,
             onRequestStarted = onRequestStarted
         )
+    }
+
+    fun startRevision(
+        context: Context,
+        baseDraft: ImportDraft,
+        instruction: String,
+        baseProgress: AiEduImportProgress,
+        settings: AiImportSettings,
+        historicalEntryId: String?
+    ): String {
+        val appContext = context.applicationContext
+        val taskId = baseProgress.taskId.ifBlank { UUID.randomUUID().toString() }
+        activeJob?.cancel()
+        AiEduImportProgressSession.setPreviewDraft(baseDraft)
+        AiEduImportProgressSession.update(
+            baseProgress.copy(
+                taskId = taskId,
+                steps = baseProgress.steps + "正在理解你的修改要求",
+                userPrompt = instruction,
+                liveSummary = "正在理解你的修改要求，并核对现有课程、周次和节次。",
+                requestSent = true,
+                finished = false,
+                error = null
+            )
+        )
+        AiImportForegroundService.start(appContext, taskId, "正在理解修改要求")
+        activeJob = taskScope.launch {
+            try {
+                runRevision(
+                    context = appContext,
+                    taskId = taskId,
+                    baseDraft = baseDraft,
+                    instruction = instruction,
+                    baseProgress = baseProgress,
+                    settings = settings,
+                    historicalEntryId = historicalEntryId
+                )
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
+                finishFailure(appContext, taskId, error, "AI 修改任务未完成")
+            }
+        }
+        return taskId
     }
 
     private fun startTask(
@@ -165,6 +210,85 @@ object AiImportTaskManager {
         }
         AiImportHistoryStore.record(context, preview, completed)
         AiImportForegroundService.complete(context, taskId, preview.courses.size)
+    }
+
+    private suspend fun runRevision(
+        context: Context,
+        taskId: String,
+        baseDraft: ImportDraft,
+        instruction: String,
+        baseProgress: AiEduImportProgress,
+        settings: AiImportSettings,
+        historicalEntryId: String?
+    ) = coroutineScope {
+        appendMainStep(taskId, context, "AI 正在修改课程", "正在核对现有课表结构并生成修改方案。")
+        val summaryTicker = launch {
+            listOf(
+                "正在核对课程、周次和节次",
+                "正在生成课程修改方案",
+                "正在等待模型返回完整结果"
+            ).forEach { summary ->
+                delay(2_600)
+                if (isActive) updateMicroStatus(taskId, summary)
+            }
+        }
+        val result = AiScheduleImportService(context)
+            .reviseSchedule(baseDraft, instruction, baseProgress, settings)
+            .getOrElse { error ->
+                summaryTicker.cancel()
+                finishFailure(context, taskId, error, "AI 修改请求失败")
+                return@coroutineScope
+            }
+        summaryTicker.cancel()
+        update(taskId) {
+            it.copy(reasoningOutput = result.reasoningOutput, aiOutput = result.rawOutput)
+        }
+        appendMainStep(taskId, context, "正在校验课程数据", "正在检查修改后的星期、节次和周次。")
+        val revised = ScheduleImportParser.parse(
+            result.output.ifBlank { result.rawOutput },
+            baseDraft.config
+        ).getOrElse { error ->
+            finishFailure(context, taskId, error, "修改结果校验失败")
+            return@coroutineScope
+        }.copy(source = ImportDraftSource.AI_EDU)
+        appendMainStep(taskId, context, "正在生成导入预览", "修改结果已通过校验，正在更新导入预览。")
+        AiEduImportProgressSession.setPreviewDraft(revised)
+        val previousTurns = baseProgress.conversationTurns.ifEmpty {
+            listOf(
+                AiEduImportConversationTurn(
+                    userPrompt = baseProgress.userPrompt,
+                    reasoningOutput = baseProgress.reasoningOutput,
+                    aiOutput = baseProgress.aiOutput
+                )
+            )
+        }
+        val completed = update(taskId) {
+            it.copy(
+                steps = it.steps + "完成",
+                userPrompt = instruction,
+                requestSent = true,
+                reasoningOutput = result.reasoningOutput,
+                aiOutput = result.rawOutput,
+                liveSummary = result.reasoningOutput.ifBlank {
+                    "本轮已按你的要求更新课表，并通过本地校验。"
+                },
+                finished = true,
+                error = null,
+                conversationTurns = previousTurns + AiEduImportConversationTurn(
+                    userPrompt = instruction,
+                    reasoningOutput = result.reasoningOutput,
+                    aiOutput = result.rawOutput
+                )
+            )
+        }
+        if (completed != null) {
+            if (historicalEntryId != null) {
+                AiImportHistoryStore.update(context, historicalEntryId, revised, completed)
+            } else {
+                AiImportHistoryStore.updateMatching(context, baseDraft, revised, completed)
+            }
+        }
+        AiImportForegroundService.complete(context, taskId, revised.courses.size)
     }
 
     private fun appendMainStep(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
@@ -6,8 +6,11 @@ import com.xiaomanjun.sleepdownschedule.model.ImportDraft
 import com.xiaomanjun.sleepdownschedule.model.ImportDraftSource
 
 import android.content.Context
+import android.os.PowerManager
+import com.xiaomanjun.sleepdownschedule.CourseScheduleApp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -152,8 +155,39 @@ object AiImportTaskManager {
         return taskId
     }
 
-    internal fun launchPending(taskId: String, scope: CoroutineScope): Job? =
-        pendingTasks.remove(taskId)?.let { task -> scope.launch { task() } }
+    @Volatile
+    private var activeJob: Job? = null
+    private var wakeLock: PowerManager.WakeLock? = null
+
+    // The workflow runs on the process application scope, not on the foreground service:
+    // OEM battery guards may stop the service at any moment while the app is backgrounded,
+    // and the in-flight AI request must survive that instead of dying with the service scope.
+    internal fun launchPending(context: Context, taskId: String): Job? {
+        val task = pendingTasks.remove(taskId) ?: return null
+        activeJob?.cancel()
+        val appContext = context.applicationContext
+        acquireWakeLock(appContext)
+        val scope = (appContext as CourseScheduleApp).applicationScope
+        return scope.launch(Dispatchers.IO) {
+            try {
+                task()
+            } finally {
+                releaseWakeLock()
+            }
+        }.also { activeJob = it }
+    }
+
+    private fun acquireWakeLock(context: Context) {
+        if (wakeLock?.isHeld == true) return
+        wakeLock = context.getSystemService(PowerManager::class.java)
+            ?.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SleepDown:ai_import")
+            ?.apply { acquire(AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS) }
+    }
+
+    private fun releaseWakeLock() {
+        wakeLock?.takeIf { it.isHeld }?.release()
+        wakeLock = null
+    }
 
     private suspend fun runTask(
         context: Context,
@@ -342,4 +376,6 @@ object AiImportTaskManager {
             ?: return null
         return transform(current).copy(taskId = taskId).also(AiEduImportProgressSession::update)
     }
+
+    private const val AI_IMPORT_WAKE_LOCK_TIMEOUT_MILLIS = 30L * 60L * 1_000L
 }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/AiImportTaskManager.kt
@@ -8,21 +8,19 @@ import com.xiaomanjun.sleepdownschedule.model.ImportDraftSource
 import android.content.Context
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 /** Owns the single active AI import after the user has confirmed sending its input. */
 object AiImportTaskManager {
     const val EXTRA_TASK_ID = "ai_import_task_id"
 
-    private val taskScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var activeJob: Job? = null
+    private val pendingTasks = ConcurrentHashMap<String, suspend () -> Unit>()
 
     fun startFileImport(
         context: Context,
@@ -84,7 +82,6 @@ object AiImportTaskManager {
     ): String {
         val appContext = context.applicationContext
         val taskId = baseProgress.taskId.ifBlank { UUID.randomUUID().toString() }
-        activeJob?.cancel()
         AiEduImportProgressSession.setPreviewDraft(baseDraft)
         AiEduImportProgressSession.update(
             baseProgress.copy(
@@ -97,8 +94,8 @@ object AiImportTaskManager {
                 error = null
             )
         )
-        AiImportForegroundService.start(appContext, taskId, "正在理解修改要求")
-        activeJob = taskScope.launch {
+        pendingTasks.clear()
+        pendingTasks[taskId] = {
             try {
                 runRevision(
                     context = appContext,
@@ -115,6 +112,7 @@ object AiImportTaskManager {
                 finishFailure(appContext, taskId, error, "AI 修改任务未完成")
             }
         }
+        AiImportForegroundService.start(appContext, taskId, "正在理解修改要求")
         return taskId
     }
 
@@ -126,7 +124,6 @@ object AiImportTaskManager {
     ): String {
         val appContext = context.applicationContext
         val taskId = UUID.randomUUID().toString()
-        activeJob?.cancel()
         AiEduImportProgressSession.setPreviewDraft(null)
         AiEduImportProgressSession.update(
             initialProgress.copy(
@@ -141,8 +138,8 @@ object AiImportTaskManager {
                 error = null
             )
         )
-        AiImportForegroundService.start(appContext, taskId, "正在整理输入")
-        activeJob = taskScope.launch {
+        pendingTasks.clear()
+        pendingTasks[taskId] = {
             try {
                 runTask(appContext, taskId, scheduleConfig, request)
             } catch (cancelled: CancellationException) {
@@ -151,8 +148,12 @@ object AiImportTaskManager {
                 finishFailure(appContext, taskId, error, "AI 导入任务未完成")
             }
         }
+        AiImportForegroundService.start(appContext, taskId, "正在整理输入")
         return taskId
     }
+
+    internal fun launchPending(taskId: String, scope: CoroutineScope): Job? =
+        pendingTasks.remove(taskId)?.let { task -> scope.launch { task() } }
 
     private suspend fun runTask(
         context: Context,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -1896,106 +1896,120 @@ private fun EduAlphabetRailDock(
                 }
                 Box(
                     modifier = Modifier
-                        .pointerInput(letters, sectionPositions, haptic) {
-                            awaitPointerEventScope {
-                                var lastIndex = -1
-                                while (true) {
-                                    val event = awaitPointerEvent()
-                                    val pressed = event.changes.firstOrNull { it.pressed }
-                                    if (pressed == null) {
-                                        railDragging = false
-                                        railPointerIndex = -1
-                                        lastIndex = -1
-                                        continue
-                                    }
-                                    railDragging = true
-                                    val itemHeight = size.height / letters.size.toFloat()
-                                    val index = (pressed.position.y / itemHeight).toInt().coerceIn(0, letters.lastIndex)
-                                    if (index == lastIndex) continue
-                                    lastIndex = index
-                                    railPointerIndex = index
-                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                                    sectionPositions[letters[index]]?.let { position ->
-                                        scope.launch { listState.scrollToItem(position) }
-                                    }
-                                }
-                            }
-                        }
-                        .width(alphabetRailWidth)
+                        .width(96.dp),
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+                    // The veil owns a fixed 2D envelope. It is measured from the alphabet content
+                    // plus top/bottom fade space, but never participates in touch handling or the
+                    // rail's 10dp -> 58dp content-width animation.
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
                         .progressiveBackdropBlur(
                             backdrop = backdrop,
                             tintColor = railTint,
-                            // Softer than the top-bar gradient blur: lower radius and tint.
                             blurRadius = 8.dp,
                             tintIntensity = if (appUsesDarkTheme(config)) 0.08f else 0.18f,
                             domain = GlassBackdropDomain.ChromeCombined,
-                            direction = ProgressiveBlurDirection.LeftToRight,
-                            topMaskFadeStart = 0.08f,
-                            topMaskFadeEnd = 1f,
-                            topTintFadeStart = 0.18f,
-                            topTintFadeEnd = 1f,
+                            direction = ProgressiveBlurDirection.RailThreeWay,
+                            topMaskFadeStart = 0.04f,
+                            topMaskFadeEnd = 0.96f,
+                            topTintFadeStart = 0.12f,
+                            topTintFadeEnd = 0.98f,
                             fallbackTintStops = listOf(
-                                0f to ComposeColor.Transparent,
-                                0.42f to railTint.copy(alpha = 0.08f),
-                                1f to railTint.copy(alpha = 0.40f)
+                                0f to railTint.copy(alpha = 0.40f),
+                                0.58f to railTint.copy(alpha = 0.08f),
+                                1f to ComposeColor.Transparent
                             )
                         )
-                        .then(
-                            // Stable open/closed states stay layer-free; the offscreen motion
-                            // blur layer is mounted only while the rail fades in or out, so the
-                            // gradient blur is never re-sampled through a rectangular layer.
-                            if (railMotionProgress > 0.001f && railMotionProgress < 0.999f) {
-                                Modifier.graphicsLayer {
-                                    compositingStrategy = CompositingStrategy.Offscreen
-                                    renderEffect = platformBlurRenderEffect(
-                                        detailMotionBlurRadiusDp(railMotionProgress) * density.density
-                                    )
-                                }
-                            } else {
-                                Modifier
-                            }
-                        ),
-                    contentAlignment = Alignment.CenterEnd
-                ) {
-                    Column(
+                    )
+                    Box(
                         modifier = Modifier
-                            .graphicsLayer { alpha = alphabetContentAlpha }
-                            .padding(horizontal = 5.dp, vertical = 8.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(1.dp)
+                            .align(Alignment.CenterEnd)
+                            .padding(vertical = 32.dp)
                     ) {
-                        letters.forEachIndexed { index, letter ->
-                            // The blue highlight rides the spring-driven indicator, so it
-                            // glides nonlinearly between letters instead of snapping.
-                            val highlight = (1f - abs(
-                                index.toFloat() - alphabetIndicatorProgress
-                            )).coerceIn(0f, 1f)
-                            Text(
-                                letter,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .clip(RoundedCornerShape(50))
-                                    .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = null
-                                    ) {
-                                        haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                                        sectionPositions[letter]?.let { position ->
-                                            scope.launch { listState.animateScrollToItem(position) }
+                        Box(
+                            modifier = Modifier
+                                .pointerInput(letters, sectionPositions, haptic) {
+                                    awaitPointerEventScope {
+                                        var lastIndex = -1
+                                        while (true) {
+                                            val event = awaitPointerEvent()
+                                            val pressed = event.changes.firstOrNull { it.pressed }
+                                            if (pressed == null) {
+                                                railDragging = false
+                                                railPointerIndex = -1
+                                                lastIndex = -1
+                                                continue
+                                            }
+                                            railDragging = true
+                                            val itemHeight = size.height / letters.size.toFloat()
+                                            val index = (pressed.position.y / itemHeight).toInt()
+                                                .coerceIn(0, letters.lastIndex)
+                                            if (index == lastIndex) continue
+                                            lastIndex = index
+                                            railPointerIndex = index
+                                            haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                            sectionPositions[letters[index]]?.let { position ->
+                                                scope.launch { listState.scrollToItem(position) }
+                                            }
                                         }
                                     }
-                                    .padding(horizontal = 4.dp, vertical = 1.dp),
-                                color = lerp(
-                                    sleepDownPanelForegroundColor(config).copy(
-                                        alpha = if (appUsesDarkTheme(config)) 0.52f else 0.68f
-                                    ),
-                                    ComposeColor(0xFF0A84FF),
-                                    highlight
+                                }
+                                .width(alphabetRailWidth)
+                                .then(
+                                    if (railMotionProgress > 0.001f && railMotionProgress < 0.999f) {
+                                        Modifier.graphicsLayer {
+                                            compositingStrategy = CompositingStrategy.Offscreen
+                                            renderEffect = platformBlurRenderEffect(
+                                                detailMotionBlurRadiusDp(railMotionProgress) * density.density
+                                            )
+                                        }
+                                    } else {
+                                        Modifier
+                                    }
                                 ),
-                                style = MaterialTheme.typography.labelSmall,
-                                fontWeight = FontWeight.SemiBold,
-                                textAlign = TextAlign.Center
-                            )
+                            contentAlignment = Alignment.CenterEnd
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .graphicsLayer { alpha = alphabetContentAlpha }
+                                    .padding(horizontal = 5.dp, vertical = 8.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(1.dp)
+                            ) {
+                                letters.forEachIndexed { index, letter ->
+                                    val highlight = (1f - abs(
+                                        index.toFloat() - alphabetIndicatorProgress
+                                    )).coerceIn(0f, 1f)
+                                    Text(
+                                        letter,
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .clip(RoundedCornerShape(50))
+                                            .clickable(
+                                                interactionSource = remember { MutableInteractionSource() },
+                                                indication = null
+                                            ) {
+                                                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                                sectionPositions[letter]?.let { position ->
+                                                    scope.launch { listState.animateScrollToItem(position) }
+                                                }
+                                            }
+                                            .padding(horizontal = 4.dp, vertical = 1.dp),
+                                        color = lerp(
+                                            sleepDownPanelForegroundColor(config).copy(
+                                                alpha = if (appUsesDarkTheme(config)) 0.52f else 0.68f
+                                            ),
+                                            ComposeColor(0xFF0A84FF),
+                                            highlight
+                                        ),
+                                        style = MaterialTheme.typography.labelSmall,
+                                        fontWeight = FontWeight.SemiBold,
+                                        textAlign = TextAlign.Center
+                                    )
+                                }
+                            }
                         }
                     }
                 }
@@ -3772,13 +3786,28 @@ private fun AiImportChatPreview(
     onConfirm: (Boolean) -> Unit
 ) {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
     val progress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
+    val sessionDraft by AiEduImportProgressSession.previewDraft.collectAsStateWithLifecycle()
     val textColor = glassForegroundColor(settingsVisualConfig(draft.config))
     var traceExpanded by remember { mutableStateOf(false) }
     var revisionText by remember(draft) { mutableStateOf("") }
     var revising by remember { mutableStateOf(false) }
+    var ownedRevisionTaskId by remember { mutableStateOf<String?>(null) }
     var revisionError by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(ownedRevisionTaskId, progress?.taskId, progress?.finished, progress?.error, sessionDraft) {
+        val taskId = ownedRevisionTaskId ?: return@LaunchedEffect
+        val taskProgress = progress?.takeIf { it.taskId == taskId && it.finished } ?: return@LaunchedEffect
+        revisionError = taskProgress.error
+        if (taskProgress.error == null) {
+            sessionDraft?.let { revised ->
+                revisionText = ""
+                onDraftChanged?.invoke(revised)
+            }
+        }
+        revising = false
+        ownedRevisionTaskId = null
+    }
     Column(Modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier.weight(1f),
@@ -3878,61 +3907,16 @@ private fun AiImportChatPreview(
                         if (instruction.isNotEmpty() && !revising) {
                             revising = true
                             revisionError = null
-                            scope.launch {
-                                val settings = AiImportSettingsStore.load(context)
-                                val baseProgress = progress ?: AiEduImportProgress(routeLabel = "AI 手动导入")
-                                AiEduImportProgressSession.update(
-                                    baseProgress.copy(
-                                        steps = (progress?.steps.orEmpty() + "按你的要求修改课表").distinct(),
-                                        userPrompt = instruction,
-                                        requestSent = true,
-                                        finished = false,
-                                        error = null
-                                    )
-                                )
-                                AiScheduleImportService(context)
-                                    .reviseSchedule(draft, instruction, baseProgress, settings)
-                                    .mapCatching { result ->
-                                        ScheduleImportParser.parse(
-                                            result.output.ifBlank { result.rawOutput },
-                                            draft.config
-                                        ).getOrThrow() to result
-                                    }
-                                    .onSuccess { (revised, result) ->
-                                        val next = revised.copy(source = ImportDraftSource.AI_EDU)
-                                        val previousTurns = baseProgress.conversationTurns.ifEmpty {
-                                            listOf(
-                                                AiEduImportConversationTurn(
-                                                    userPrompt = baseProgress.userPrompt,
-                                                    reasoningOutput = baseProgress.reasoningOutput,
-                                                    aiOutput = baseProgress.aiOutput
-                                                )
-                                            )
-                                        }
-                                        val nextProgress = baseProgress.copy(
-                                            steps = (baseProgress.steps + listOf("已理解修改要求", "已调用课表导入工具", "修改结果通过本地校验")).distinct(),
-                                            userPrompt = instruction,
-                                            requestSent = true,
-                                            reasoningOutput = result.reasoningOutput,
-                                            aiOutput = result.rawOutput,
-                                            finished = true,
-                                            error = null,
-                                            conversationTurns = previousTurns + AiEduImportConversationTurn(
-                                                userPrompt = instruction,
-                                                reasoningOutput = result.reasoningOutput,
-                                                aiOutput = result.rawOutput
-                                            )
-                                        )
-                                        revisionText = ""
-                                        AiEduImportProgressSession.update(nextProgress)
-                                        AiImportHistoryStore.updateMatching(context, draft, next, nextProgress)
-                                        onDraftChanged(next)
-                                    }
-                                    .onFailure {
-                                        revisionError = it.message ?: "AI 没有完成这次修改，请换一种说法重试"
-                                    }
-                                revising = false
-                            }
+                            val settings = AiImportSettingsStore.load(context)
+                            val baseProgress = progress ?: AiEduImportProgress(routeLabel = "AI 手动导入")
+                            ownedRevisionTaskId = AiImportTaskManager.startRevision(
+                                context = context,
+                                baseDraft = draft,
+                                instruction = instruction,
+                                baseProgress = baseProgress,
+                                settings = settings,
+                                historicalEntryId = null
+                            )
                         }
                     }
                 )

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -469,6 +469,13 @@ fun NormalizedAiManualImportScreen(
     var aiSettings by remember { mutableStateOf(AiImportSettingsStore.load(context)) }
     var historySourceHidden by remember { mutableStateOf(false) }
     var historyEntries by remember { mutableStateOf(AiImportHistoryStore.load(context)) }
+    val taskProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
+    LaunchedEffect(taskProgress?.taskId, taskProgress?.finished) {
+        val completed = taskProgress?.takeIf { it.taskId.isNotBlank() && it.finished } ?: return@LaunchedEffect
+        aiParsing = false
+        routeMessage = completed.liveSummary.ifBlank { completed.steps.lastOrNull().orEmpty() }
+        error = completed.error
+    }
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -752,100 +759,19 @@ fun NormalizedAiManualImportScreen(
                     )
                     AiEduImportProgressSession.setActions(
                         onConfirm = {
-                            scope.launch {
-                                aiParsing = true
-                                routeMessage = "正在使用 ${settings.profile.displayName} 解析 ${file.displayName}..."
-                                AiEduImportProgressSession.update(
-                                    AiEduImportProgressSession.progress.value?.copy(
-                                        steps = listOf("已读取文件", "已确认发送", "正在调用模型解析"),
-                                        requestSent = true,
-                                        awaitingConfirmation = false,
-                                        confirmActionLabel = "",
-                                        cancelActionLabel = ""
-                                    )
-                                )
-                                AiScheduleImportService(context).parseScheduleFile(file, settings)
-                        .onSuccess { aiResult ->
-                            routeMessage = aiResult.routeMessage
-                            val output = aiResult.output.ifBlank { aiResult.rawOutput }
-                            AiEduImportProgressSession.update(
-                                AiEduImportProgress(
-                                    routeLabel = "AI 手动导入",
-                                    steps = listOf("准备读取文件", "已读取文件", "已发送给 AI", "AI 已返回可见文本，开始本地校验"),
-                                    requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n文件：${file.displayName}\n处理路线：${aiResult.routeMessage}",
-                                    pageText = fileSummary,
-                                    attachmentTitle = file.displayName,
-                                    screenshotPreviews = previewImages,
-                                    requestSent = true,
-                                    reasoningOutput = aiResult.reasoningOutput,
-                                    aiOutput = aiResult.rawOutput
-                                )
+                            aiParsing = true
+                            routeMessage = "正在使用 ${settings.profile.displayName} 解析 ${file.displayName}..."
+                            val initial = checkNotNull(AiEduImportProgressSession.progress.value).copy(
+                                steps = listOf("已读取文件", "已确认发送"),
+                                requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n文件：${file.displayName}"
                             )
-                            ScheduleImportParser.parse(output, state.config)
-                                .onSuccess { draft ->
-                                    error = null
-                                    AiEduImportProgressSession.update(
-                                        AiEduImportProgress(
-                                            routeLabel = "AI 手动导入",
-                                            steps = listOf("准备读取文件", "已读取文件", "已发送给 AI", "AI 已返回可见文本", "本地校验通过，进入导入预览"),
-                                            requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n文件：${file.displayName}\n处理路线：${aiResult.routeMessage}",
-                                            pageText = fileSummary,
-                                            attachmentTitle = file.displayName,
-                                            screenshotPreviews = previewImages,
-                                            requestSent = true,
-                                            reasoningOutput = aiResult.reasoningOutput,
-                                            aiOutput = aiResult.rawOutput,
-                                            finished = true
-                                        )
-                                    )
-                                    val preview = draft.copy(source = ImportDraftSource.AI_EDU)
-                                    AiImportHistoryStore.record(
-                                        context,
-                                        preview,
-                                        AiEduImportProgressSession.progress.value
-                                    )
-                                    AiEduImportProgressSession.setPreviewDraft(preview)
-                                }
-                                .onFailure {
-                                    error = "AI 已返回内容，但本地解析失败：${it.message ?: "未知错误"}"
-                                    AiEduImportProgressSession.update(
-                                        AiEduImportProgress(
-                                            routeLabel = "AI 手动导入",
-                                            steps = listOf("准备读取文件", "已读取文件", "已发送给 AI", "AI 已返回可见文本", "本地校验失败"),
-                                            requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n文件：${file.displayName}\n处理路线：${aiResult.routeMessage}",
-                                            pageText = fileSummary,
-                                            attachmentTitle = file.displayName,
-                                            screenshotPreviews = previewImages,
-                                            requestSent = true,
-                                            reasoningOutput = aiResult.reasoningOutput,
-                                            aiOutput = aiResult.rawOutput,
-                                            error = it.message ?: "AI 返回内容无法解析",
-                                            finished = true
-                                        )
-                                    )
-                                }
-                        }
-                        .onFailure {
-                            error = it.message ?: "AI 文件解析失败"
-                            val rawBody = it.aiRawResponseBody().orEmpty()
-                            AiEduImportProgressSession.update(
-                                AiEduImportProgress(
-                                    routeLabel = "AI 手动导入",
-                                    steps = listOf("准备读取文件", "已读取文件", "AI 请求失败"),
-                                    requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n文件：${file.displayName}",
-                                    pageText = fileSummary,
-                                    attachmentTitle = file.displayName,
-                                    screenshotPreviews = previewImages,
-                                    requestSent = true,
-                                    reasoningOutput = extractAiReasoningForDisplay(rawBody),
-                                    aiOutput = sanitizeAiOutputForDisplay(rawBody),
-                                    error = it.message ?: "AI 文件解析失败",
-                                    finished = true
-                                )
+                            AiImportTaskManager.startFileImport(
+                                context = context,
+                                file = file,
+                                settings = settings,
+                                scheduleConfig = state.config,
+                                initialProgress = initial
                             )
-                        }
-                                aiParsing = false
-                            }
                         },
                         onCancel = {
                             aiParsing = false
@@ -926,90 +852,25 @@ fun NormalizedAiManualImportScreen(
         )
         AiEduImportProgressSession.setActions(
             onConfirm = {
-                scope.launch {
-                    routeMessage = "正在使用 ${settings.profile.displayName} 整理课表口令..."
-                    AiEduImportProgressSession.update(
-                        AiEduImportProgressSession.progress.value?.copy(
-                            steps = listOf("本地口令校验未通过", "已确认发送", "正在调用模型整理"),
-                            requestSent = true,
-                            awaitingConfirmation = false,
-                            confirmActionLabel = "",
-                            cancelActionLabel = ""
-                        )
-                    )
-            val repairInput = buildString {
-                appendLine("下面是一个格式不完整或不规范的 SleepDown 课程表口令。")
-                appendLine("请理解其中的课程信息，严格按照 SleepDown 课表导入协议整理并只返回可导入结果。")
-                appendLine()
-                append(jsonText)
-            }
-            AiScheduleImportService(context)
-                .parseScheduleText(repairInput, "手动粘贴的非标准课表口令", settings)
-                .onSuccess { aiResult ->
-                    val output = aiResult.output.ifBlank { aiResult.rawOutput }
-                    ScheduleImportParser.parse(output, state.config)
-                        .onSuccess { draft ->
-                            error = null
-                            routeMessage = "AI 已完成口令整理。"
-                            AiEduImportProgressSession.update(
-                                AiEduImportProgress(
-                                    routeLabel = "AI 手动导入",
-                                    steps = listOf("本地口令校验未通过", "AI 已完成整理", "本地校验通过，进入导入预览"),
-                                    requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n输入：用户粘贴的非标准课表口令",
-                                    userPrompt = "帮我按规则整理并导入这份课表",
-                                    attachmentTitle = "课表口令文本",
-                                    pageText = jsonText.take(40_000),
-                                    requestSent = true,
-                                    reasoningOutput = aiResult.reasoningOutput,
-                                    aiOutput = aiResult.rawOutput,
-                                    finished = true
-                                )
-                            )
-                            val preview = draft.copy(source = ImportDraftSource.AI_EDU)
-                            AiImportHistoryStore.record(
-                                context,
-                                preview,
-                                AiEduImportProgressSession.progress.value
-                            )
-                            AiEduImportProgressSession.setPreviewDraft(preview)
-                        }
-                        .onFailure {
-                            error = "AI 已整理口令，但仍无法导入：${it.message ?: "未知错误"}"
-                            AiEduImportProgressSession.update(
-                                AiEduImportProgress(
-                                    routeLabel = "AI 手动导入",
-                                    steps = listOf("本地口令校验未通过", "AI 已完成整理", "本地校验仍未通过"),
-                                    requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}",
-                                    userPrompt = "帮我按规则整理并导入这份课表",
-                                    attachmentTitle = "课表口令文本",
-                                    pageText = jsonText.take(40_000),
-                                    requestSent = true,
-                                    reasoningOutput = aiResult.reasoningOutput,
-                                    aiOutput = aiResult.rawOutput,
-                                    error = it.message ?: "AI 返回内容无法解析",
-                                    finished = true
-                                )
-                            )
-                        }
+                routeMessage = "正在使用 ${settings.profile.displayName} 整理课表口令..."
+                val repairInput = buildString {
+                    appendLine("下面是一个格式不完整或不规范的 SleepDown 课程表口令。")
+                    appendLine("请理解其中的课程信息，严格按照 SleepDown 课表导入协议整理并只返回可导入结果。")
+                    appendLine()
+                    append(jsonText)
                 }
-                .onFailure {
-                    error = it.message ?: "AI 口令整理失败"
-                    AiEduImportProgressSession.update(
-                        AiEduImportProgress(
-                            routeLabel = "AI 手动导入",
-                            steps = listOf("本地口令校验未通过", "AI 整理请求失败"),
-                            requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}",
-                            userPrompt = "帮我按规则整理并导入这份课表",
-                            attachmentTitle = "课表口令文本",
-                            pageText = jsonText.take(40_000),
-                            requestSent = true,
-                            error = it.message ?: "AI 口令整理失败",
-                            finished = true
-                        )
-                    )
-                }
-            aiParsing = false
-                }
+                val initial = checkNotNull(AiEduImportProgressSession.progress.value).copy(
+                    steps = listOf("本地口令校验未通过", "已确认发送"),
+                    requestPreview = "服务商：${settings.profile.displayName}\n模型：${settings.profile.defaultModel}\n输入：用户粘贴的非标准课表口令"
+                )
+                AiImportTaskManager.startTextImport(
+                    context = context,
+                    text = repairInput,
+                    sourceName = "手动粘贴的非标准课表口令",
+                    settings = settings,
+                    scheduleConfig = state.config,
+                    initialProgress = initial
+                )
             },
             onCancel = {
                 aiParsing = false
@@ -3143,6 +3004,15 @@ fun EduImportBrowserScreen(
     var pendingOriginalImportScript by remember(adapter) { mutableStateOf<String?>(null) }
     var pendingImportGeneration by remember(adapter) { mutableIntStateOf(0) }
     var importGeneration by remember(adapter) { mutableIntStateOf(0) }
+    val taskProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
+    LaunchedEffect(taskProgress?.taskId, taskProgress?.finished) {
+        val completed = taskProgress?.takeIf {
+            it.taskId.isNotBlank() && it.routeLabel == "AI教务导入" && it.finished
+        } ?: return@LaunchedEffect
+        aiProgress = completed
+        aiParsing = false
+        onMessage(completed.error ?: completed.liveSummary.ifBlank { completed.steps.lastOrNull().orEmpty() })
+    }
     val topPadding = if (useDetailTopPadding) detailContentTopPadding() else 0.dp
     val normalizedUrl = remember(addressText) {
         normalizeEduUrl(addressText)
@@ -3204,7 +3074,7 @@ fun EduImportBrowserScreen(
             AiEduImportProgressSession.clearActions()
             setAiProgress(aiProgress?.copy(
                 awaitingConfirmation = false,
-                requestSent = true,
+                requestSent = false,
                 confirmActionLabel = "",
                 secondaryConfirmActionLabel = "",
                 screenModeActionLabel = "",
@@ -3214,66 +3084,20 @@ fun EduImportBrowserScreen(
                     "用户确认只发送截图给 AI"
                 })
             ))
-            scope.launch {
-                if (settings.apiKey.isBlank()) {
-                    setAiProgress(aiProgress?.copy(
-                        steps = aiProgress?.steps.orEmpty() + "缺少 AI API Key",
-                        error = "请先在设置中配置 AI API Key",
-                        finished = true
-                    ))
-                    onMessage("请先在设置中配置 AI API Key")
-                    aiParsing = false
-                    return@launch
-                }
-                appendAiStep("已读取 AI 配置：${settings.profile.displayName} / ${settings.profile.defaultModel}")
-                appendAiStep("正在发送给 AI 解析")
-                onMessage("AI 正在解析当前教务页面...")
-                AiScheduleImportService(context)
-                    .parseScheduleCapturedPage(
-                        text = aiPageText,
-                        screenshots = capture.screenshots,
-                        sourceName = routeLabel,
-                        warnings = capture.warnings,
-                        settings = settings
-                    )
-                    .onSuccess { result ->
-                        setAiProgress(aiProgress?.copy(
-                            steps = aiProgress?.steps.orEmpty() + "AI 已返回可见文本，开始本地校验",
-                            reasoningOutput = result.reasoningOutput,
-                            aiOutput = result.rawOutput
-                        ))
-                        ScheduleImportParser.parse(result.output, state.config)
-                            .onSuccess {
-                                setAiProgress(aiProgress?.copy(
-                                    steps = aiProgress?.steps.orEmpty() + "本地校验通过，即将进入导入预览",
-                                    finished = true
-                                ))
-                                onMessage(result.routeMessage)
-                                val preview = it.copy(source = ImportDraftSource.AI_EDU)
-                                AiEduImportProgressSession.setPreviewDraft(preview)
-                            }
-                            .onFailure {
-                                setAiProgress(aiProgress?.copy(
-                                    steps = aiProgress?.steps.orEmpty() + "本地校验失败",
-                                    error = it.message ?: "AI 返回内容无法解析",
-                                    finished = true
-                                ))
-                                onMessage(it.message ?: "AI 返回内容无法解析")
-                            }
-                    }
-                    .onFailure {
-                        val rawBody = it.aiRawResponseBody().orEmpty()
-                        setAiProgress(aiProgress?.copy(
-                            steps = aiProgress?.steps.orEmpty() + "AI 请求失败",
-                            reasoningOutput = extractAiReasoningForDisplay(rawBody),
-                            aiOutput = sanitizeAiOutputForDisplay(rawBody),
-                            error = it.message ?: "AI 解析失败",
-                            finished = true
-                        ))
-                        onMessage(it.message ?: "AI 解析失败")
-                    }
-                aiParsing = false
-            }
+            val initial = checkNotNull(aiProgress).copy(
+                requestPreview = aiEduRequestPreview(settings, aiPageText.length)
+            )
+            onMessage("AI 正在解析当前教务页面...")
+            AiImportTaskManager.startCapturedPageImport(
+                context = context,
+                text = aiPageText,
+                screenshots = capture.screenshots,
+                sourceName = routeLabel,
+                warnings = capture.warnings,
+                settings = settings,
+                scheduleConfig = state.config,
+                initialProgress = initial
+            )
         }
 
         fun prepareCapturePreview(capture: EduPageCaptureResult, settings: AiImportSettings, screenMode: Boolean) {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -1723,7 +1723,7 @@ fun EduSchoolIndexedSelectScreen(
     }
     val activeAlphabetIndex = railPointerIndex.takeIf { it >= 0 } ?: visibleSectionIndex
     val alphabetRailWidth by animateDpAsState(
-        targetValue = if (alphabetRailExpanded) 34.dp else 10.dp,
+        targetValue = if (alphabetRailExpanded) 58.dp else 10.dp,
         animationSpec = tween(180),
         label = "edu-alphabet-width"
     )
@@ -1811,7 +1811,6 @@ fun EduSchoolIndexedSelectScreen(
             )
         }
         if (letters.isNotEmpty()) {
-            var railContentSize by remember(letters) { mutableStateOf(IntSize.Zero) }
             val railModifier = Modifier
                     .pointerInput(letters, sectionPositions, haptic) {
                         awaitPointerEventScope {
@@ -1839,52 +1838,9 @@ fun EduSchoolIndexedSelectScreen(
                         }
                     }
             val railContent: @Composable () -> Unit = {
-                val density = LocalDensity.current
-                val verticalPaddingPx = with(density) { 16.dp.toPx() }
-                val itemSpacingPx = with(density) { 1.dp.toPx() }
-                val letterTrackHeightPx = (
-                    railContentSize.height.toFloat() - verticalPaddingPx
-                    ).coerceAtLeast(0f)
-                // The marker and labels share the same row grid. Include the Column's
-                // inter-item spacing in that grid, otherwise the marker drifts farther from the
-                // labels on every row and the rail looks vertically skewed.
-                val letterSlotHeightPx = (
-                    letterTrackHeightPx - itemSpacingPx * (letters.size - 1).coerceAtLeast(0)
-                ).coerceAtLeast(0f) / letters.size.toFloat()
-                val letterStepPx = letterSlotHeightPx + itemSpacingPx
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .onSizeChanged { railContentSize = it }
+                    modifier = Modifier.width(34.dp)
                 ) {
-                    if (letterSlotHeightPx > 0f) {
-                        // The rail shell owns the sampled material. Keep the current-position
-                        // marker as a flat accent so it cannot cover or compete with that glass.
-                        Box(
-                            modifier = Modifier
-                                .align(Alignment.TopCenter)
-                                .padding(horizontal = 5.dp)
-                                .fillMaxWidth()
-                                .height(with(density) { letterSlotHeightPx.toDp() })
-                                .offset {
-                                    IntOffset(
-                                        x = 0,
-                                        y = with(density) { 8.dp.roundToPx() } +
-                                            (letterStepPx * alphabetIndicatorProgress).roundToInt()
-                                    )
-                                }
-                                .graphicsLayer { alpha = alphabetContentAlpha },
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .background(
-                                        ComposeColor(0xFF0A84FF).copy(alpha = 0.82f),
-                                        Capsule()
-                                    )
-                            )
-                        }
-                    }
                     Column(
                         modifier = Modifier
                             .graphicsLayer { alpha = alphabetContentAlpha }
@@ -1909,7 +1865,7 @@ fun EduSchoolIndexedSelectScreen(
                                     }
                                     .padding(horizontal = 4.dp, vertical = 1.dp),
                                 color = if (active) {
-                                    ComposeColor.White
+                                    ComposeColor(0xFF0A84FF)
                                 } else {
                                     sleepDownPanelForegroundColor(state.config).copy(
                                         alpha = if (appUsesDarkTheme(state.config)) 0.52f else 0.68f
@@ -1948,38 +1904,38 @@ fun EduSchoolIndexedSelectScreen(
                     ) { state ->
                         if (state == EnterExitState.Visible) 1f else 0f
                     }
-                    GlassSurface(
-                        backdrop = overlayBackdrop,
-                        config = state.config,
+                    val railTint = if (appUsesDarkTheme(state.config)) {
+                        ComposeColor(0xFF111318)
+                    } else {
+                        ComposeColor.White
+                    }
+                    Box(
                         modifier = railModifier
                             .width(alphabetRailWidth)
+                            .progressiveBackdropBlur(
+                                backdrop = overlayBackdrop,
+                                tintColor = railTint,
+                                blurRadius = 10.dp,
+                                tintIntensity = if (appUsesDarkTheme(state.config)) 0.10f else 0.22f,
+                                domain = GlassBackdropDomain.ChromeCombined,
+                                direction = ProgressiveBlurDirection.LeftToRight,
+                                topMaskFadeStart = 0.08f,
+                                topMaskFadeEnd = 1f,
+                                topTintFadeStart = 0.18f,
+                                topTintFadeEnd = 1f,
+                                fallbackTintStops = listOf(
+                                    0f to ComposeColor.Transparent,
+                                    0.42f to railTint.copy(alpha = 0.10f),
+                                    1f to railTint.copy(alpha = 0.44f)
+                                )
+                            )
                             .graphicsLayer {
                                 compositingStrategy = CompositingStrategy.Offscreen
                                 renderEffect = platformBlurRenderEffect(
                                     detailMotionBlurRadiusDp(railMotionProgress) * density.density
                                 )
                             },
-                        shape = Capsule(),
-                        tokens = GlassTokens.pill(intensity = 1f).copy(
-                            // The shell is the glass consumer; the blue position marker below is
-                            // deliberately plain and does not create a second sampled surface.
-                            blur = 12.dp,
-                            lensHeight = 20.dp,
-                            lensAmount = 34.dp,
-                            surfaceAlpha = if (appUsesDarkTheme(state.config)) 0.035f else 0.22f,
-                            borderAlpha = if (appUsesDarkTheme(state.config)) 0.08f else 0.18f,
-                            highlightAlpha = if (appUsesDarkTheme(state.config)) 0.04f else 0.10f,
-                            shadowAlpha = if (appUsesDarkTheme(state.config)) 0.07f else 0.16f,
-                            innerShadowAlpha = if (appUsesDarkTheme(state.config)) 0.045f else 0.10f
-                        ),
-                        onClick = {},
-                        baseSurfaceColorOverride = if (appUsesDarkTheme(state.config)) {
-                            ComposeColor(0xFF111318)
-                        } else {
-                            ComposeColor.White
-                        },
-                        domain = GlassBackdropDomain.ChromeCombined,
-                        debugLabel = "EduAlphabetRail"
+                        contentAlignment = Alignment.CenterEnd
                     ) {
                         railContent()
                     }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -1711,10 +1711,14 @@ fun EduSchoolIndexedSelectScreen(
     }
     val visibleSectionIndex by remember(letters, sectionPositions) {
         derivedStateOf {
-            val firstVisible = listState.firstVisibleItemIndex
-            letters.indexOfLast { letter ->
-                (sectionPositions[letter] ?: Int.MAX_VALUE) <= firstVisible
-            }.coerceAtLeast(0)
+            if (!listState.canScrollForward) {
+                letters.lastIndex.coerceAtLeast(0)
+            } else {
+                val firstVisible = listState.firstVisibleItemIndex
+                letters.indexOfLast { letter ->
+                    (sectionPositions[letter] ?: Int.MAX_VALUE) <= firstVisible
+                }.coerceAtLeast(0)
+            }
         }
     }
     val activeAlphabetIndex = railPointerIndex.takeIf { it >= 0 } ?: visibleSectionIndex
@@ -1928,6 +1932,7 @@ fun EduSchoolIndexedSelectScreen(
                         top = topPadding,
                         bottom = alphabetRailBottomExclusion
                     )
+                    .clipToBounds()
             ) {
                 AnimatedVisibility(
                     visible = showAlphabetRail,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -135,6 +135,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -207,6 +208,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -214,6 +216,7 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.util.VelocityTracker
+import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInRoot
@@ -1604,6 +1607,12 @@ fun EduSchoolIndexedSelectScreen(
     val currentSearchBackdrop = rememberUpdatedState(overlayBackdrop)
     val currentSearchConfig = rememberUpdatedState(state.config)
     val currentSearchImeLift = rememberUpdatedState(imeLift)
+    val currentRailListState = rememberUpdatedState(listState)
+    val currentRailLetters = rememberUpdatedState(letters)
+    val currentRailPositions = rememberUpdatedState(sectionPositions)
+    val currentRailTopPadding = rememberUpdatedState(topPadding)
+    val currentRailScope = rememberUpdatedState(scope)
+    val currentRailHaptic = rememberUpdatedState(haptic)
     val floatingSearchDock: (@Composable () -> Unit)? = if (floatingOverlayHost != null) {
         remember(floatingOverlayHost) {
             @Composable {
@@ -1613,6 +1622,20 @@ fun EduSchoolIndexedSelectScreen(
                     backdrop = currentSearchBackdrop.value,
                     config = currentSearchConfig.value,
                     imeLift = currentSearchImeLift.value
+                )
+                // The alphabet rail floats at the same root level as the top bar, as a sibling of
+                // the Miuix Scaffold instead of a page child. Its gradient blur therefore keeps a
+                // full-window envelope and can no longer be cropped by the card/list subtrees.
+                EduAlphabetRailDock(
+                    listState = currentRailListState.value,
+                    letters = currentRailLetters.value,
+                    sectionPositions = currentRailPositions.value,
+                    backdrop = currentSearchBackdrop.value,
+                    config = currentSearchConfig.value,
+                    topPadding = currentRailTopPadding.value,
+                    imeLift = currentSearchImeLift.value,
+                    scope = currentRailScope.value,
+                    haptic = currentRailHaptic.value
                 )
             }
         }
@@ -1677,72 +1700,6 @@ fun EduSchoolIndexedSelectScreen(
     // The OS IME inset is the single source of truth for the search dock's vertical motion. The
     // field must rise with the keyboard itself; the split action below derives from that same
     // inset instead of starting a second focus-driven opening animation.
-    val searchDockBottomPadding = 18.dp
-    val searchDockHeight = 44.dp
-    val navigationBarBottom = with(density) {
-        WindowInsets.navigationBars.getBottom(density).toDp()
-    }
-    // Center the rail only in the usable list window: the measured top bar and the entire search
-    // dock (including its safe-area/IME lift) are excluded from the centering bounds.
-    val alphabetRailBottomExclusion =
-        searchDockHeight + searchDockBottomPadding + navigationBarBottom + imeLift
-    var railDragging by remember { mutableStateOf(false) }
-    var railPointerIndex by remember { mutableIntStateOf(-1) }
-    val railScrolling by remember {
-        derivedStateOf { listState.isScrollInProgress || railDragging }
-    }
-    // Keep the rail visible briefly after the list settles so it does not pop away the moment
-    // the finger leaves the screen.
-    var showAlphabetRail by remember { mutableStateOf(false) }
-    var alphabetRailExpanded by remember { mutableStateOf(false) }
-    LaunchedEffect(railScrolling) {
-        if (railScrolling) {
-            showAlphabetRail = true
-            alphabetRailExpanded = true
-        } else {
-            delay(760)
-            // Let the full glass shell perform its fade/motion-blur exit first. Collapse the
-            // width only after the visibility transition has left the composition, otherwise the
-            // blur would be applied to a 10dp sliver and the rail would look lopsided.
-            showAlphabetRail = false
-            delay(240)
-            alphabetRailExpanded = false
-        }
-    }
-    val visibleSectionIndex by remember(letters, sectionPositions) {
-        derivedStateOf {
-            if (!listState.canScrollForward) {
-                letters.lastIndex.coerceAtLeast(0)
-            } else {
-                val firstVisible = listState.firstVisibleItemIndex
-                letters.indexOfLast { letter ->
-                    (sectionPositions[letter] ?: Int.MAX_VALUE) <= firstVisible
-                }.coerceAtLeast(0)
-            }
-        }
-    }
-    val activeAlphabetIndex = railPointerIndex.takeIf { it >= 0 } ?: visibleSectionIndex
-    val alphabetRailWidth by animateDpAsState(
-        targetValue = if (alphabetRailExpanded) 58.dp else 10.dp,
-        animationSpec = tween(180),
-        label = "edu-alphabet-width"
-    )
-    val alphabetContentAlpha by animateFloatAsState(
-        targetValue = if (alphabetRailExpanded) 1f else 0f,
-        animationSpec = tween(130),
-        label = "edu-alphabet-content"
-    )
-    val alphabetIndicatorProgress by animateFloatAsState(
-        targetValue = activeAlphabetIndex
-            .coerceIn(0, letters.lastIndex.coerceAtLeast(0))
-            .toFloat(),
-        animationSpec = spring(
-            dampingRatio = 0.76f,
-            stiffness = 560f,
-            visibilityThreshold = 0.001f
-        ),
-        label = "edu-alphabet-indicator"
-    )
     Box(Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -1809,37 +1766,196 @@ fun EduSchoolIndexedSelectScreen(
                 config = state.config,
                 imeLift = imeLift
             )
+            EduAlphabetRailDock(
+                listState = listState,
+                letters = letters,
+                sectionPositions = sectionPositions,
+                backdrop = overlayBackdrop,
+                config = state.config,
+                topPadding = topPadding,
+                imeLift = imeLift,
+                scope = scope,
+                haptic = haptic
+            )
         }
-        if (letters.isNotEmpty()) {
-            val railModifier = Modifier
-                    .pointerInput(letters, sectionPositions, haptic) {
-                        awaitPointerEventScope {
-                            var lastIndex = -1
-                            while (true) {
-                                val event = awaitPointerEvent()
-                                val pressed = event.changes.firstOrNull { it.pressed }
-                                if (pressed == null) {
-                                    railDragging = false
-                                    railPointerIndex = -1
-                                    lastIndex = -1
-                                    continue
-                                }
-                                railDragging = true
-                                val itemHeight = size.height / letters.size.toFloat()
-                                val index = (pressed.position.y / itemHeight).toInt().coerceIn(0, letters.lastIndex)
-                                if (index == lastIndex) continue
-                                lastIndex = index
-                                railPointerIndex = index
-                                haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
-                                sectionPositions[letters[index]]?.let { position ->
-                                    scope.launch { listState.scrollToItem(position) }
+    }
+}
+
+
+@Composable
+private fun EduAlphabetRailDock(
+    listState: LazyListState,
+    letters: List<String>,
+    sectionPositions: Map<String, Int>,
+    backdrop: Backdrop?,
+    config: ScheduleConfigEntity,
+    topPadding: Dp,
+    imeLift: Dp,
+    scope: CoroutineScope,
+    haptic: HapticFeedback
+) {
+    if (letters.isEmpty()) return
+    val density = LocalDensity.current
+    val navigationBarBottom = with(density) {
+        WindowInsets.navigationBars.getBottom(density).toDp()
+    }
+    // Center the rail only in the usable list window: the measured top bar and the entire search
+    // dock (including its safe-area/IME lift) are excluded from the centering bounds.
+    val alphabetRailBottomExclusion = 44.dp + 18.dp + navigationBarBottom + imeLift
+    var railDragging by remember { mutableStateOf(false) }
+    var railPointerIndex by remember { mutableIntStateOf(-1) }
+    val railScrolling by remember {
+        derivedStateOf { listState.isScrollInProgress || railDragging }
+    }
+    // Keep the rail visible briefly after the list settles so it does not pop away the moment
+    // the finger leaves the screen.
+    var showAlphabetRail by remember { mutableStateOf(false) }
+    var alphabetRailExpanded by remember { mutableStateOf(false) }
+    LaunchedEffect(railScrolling) {
+        if (railScrolling) {
+            showAlphabetRail = true
+            alphabetRailExpanded = true
+        } else {
+            delay(760)
+            // Let the full glass shell perform its fade/motion-blur exit first. Collapse the
+            // width only after the visibility transition has left the composition, otherwise the
+            // blur would be applied to a 10dp sliver and the rail would look lopsided.
+            showAlphabetRail = false
+            delay(240)
+            alphabetRailExpanded = false
+        }
+    }
+    val visibleSectionIndex by remember(letters, sectionPositions) {
+        derivedStateOf {
+            if (!listState.canScrollForward) {
+                letters.lastIndex.coerceAtLeast(0)
+            } else {
+                val firstVisible = listState.firstVisibleItemIndex
+                letters.indexOfLast { letter ->
+                    (sectionPositions[letter] ?: Int.MAX_VALUE) <= firstVisible
+                }.coerceAtLeast(0)
+            }
+        }
+    }
+    val activeAlphabetIndex = railPointerIndex.takeIf { it >= 0 } ?: visibleSectionIndex
+    val alphabetRailWidth by animateDpAsState(
+        targetValue = if (alphabetRailExpanded) 58.dp else 10.dp,
+        animationSpec = tween(180),
+        label = "edu-alphabet-width"
+    )
+    val alphabetContentAlpha by animateFloatAsState(
+        targetValue = if (alphabetRailExpanded) 1f else 0f,
+        animationSpec = tween(130),
+        label = "edu-alphabet-content"
+    )
+    val alphabetIndicatorProgress by animateFloatAsState(
+        targetValue = activeAlphabetIndex
+            .coerceIn(0, letters.lastIndex.coerceAtLeast(0))
+            .toFloat(),
+        animationSpec = spring(
+            dampingRatio = 0.76f,
+            stiffness = 560f,
+            visibilityThreshold = 0.001f
+        ),
+        label = "edu-alphabet-indicator"
+    )
+    // Root-level dock: the whole window is the layout envelope, so the gradient blur can fade
+    // out toward the page without being cropped by any card/list/offscreen boundary.
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .graphicsLayer { clip = false }
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    top = topPadding,
+                    bottom = alphabetRailBottomExclusion
+                )
+                .clipToBounds()
+        ) {
+            AnimatedVisibility(
+                visible = showAlphabetRail,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 2.dp),
+                enter = fadeIn(tween(240)),
+                exit = fadeOut(tween(240))
+            ) {
+                val railMotionProgress by transition.animateFloat(
+                    transitionSpec = { tween(240) },
+                    label = "edu-alphabet-motion"
+                ) { state ->
+                    if (state == EnterExitState.Visible) 1f else 0f
+                }
+                val railTint = if (appUsesDarkTheme(config)) {
+                    ComposeColor(0xFF111318)
+                } else {
+                    ComposeColor.White
+                }
+                Box(
+                    modifier = Modifier
+                        .pointerInput(letters, sectionPositions, haptic) {
+                            awaitPointerEventScope {
+                                var lastIndex = -1
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    val pressed = event.changes.firstOrNull { it.pressed }
+                                    if (pressed == null) {
+                                        railDragging = false
+                                        railPointerIndex = -1
+                                        lastIndex = -1
+                                        continue
+                                    }
+                                    railDragging = true
+                                    val itemHeight = size.height / letters.size.toFloat()
+                                    val index = (pressed.position.y / itemHeight).toInt().coerceIn(0, letters.lastIndex)
+                                    if (index == lastIndex) continue
+                                    lastIndex = index
+                                    railPointerIndex = index
+                                    haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                                    sectionPositions[letters[index]]?.let { position ->
+                                        scope.launch { listState.scrollToItem(position) }
+                                    }
                                 }
                             }
                         }
-                    }
-            val railContent: @Composable () -> Unit = {
-                Box(
-                    modifier = Modifier.width(34.dp)
+                        .width(alphabetRailWidth)
+                        .progressiveBackdropBlur(
+                            backdrop = backdrop,
+                            tintColor = railTint,
+                            // Softer than the top-bar gradient blur: lower radius and tint.
+                            blurRadius = 8.dp,
+                            tintIntensity = if (appUsesDarkTheme(config)) 0.08f else 0.18f,
+                            domain = GlassBackdropDomain.ChromeCombined,
+                            direction = ProgressiveBlurDirection.LeftToRight,
+                            topMaskFadeStart = 0.08f,
+                            topMaskFadeEnd = 1f,
+                            topTintFadeStart = 0.18f,
+                            topTintFadeEnd = 1f,
+                            fallbackTintStops = listOf(
+                                0f to ComposeColor.Transparent,
+                                0.42f to railTint.copy(alpha = 0.08f),
+                                1f to railTint.copy(alpha = 0.40f)
+                            )
+                        )
+                        .then(
+                            // Stable open/closed states stay layer-free; the offscreen motion
+                            // blur layer is mounted only while the rail fades in or out, so the
+                            // gradient blur is never re-sampled through a rectangular layer.
+                            if (railMotionProgress > 0.001f && railMotionProgress < 0.999f) {
+                                Modifier.graphicsLayer {
+                                    compositingStrategy = CompositingStrategy.Offscreen
+                                    renderEffect = platformBlurRenderEffect(
+                                        detailMotionBlurRadiusDp(railMotionProgress) * density.density
+                                    )
+                                }
+                            } else {
+                                Modifier
+                            }
+                        ),
+                    contentAlignment = Alignment.CenterEnd
                 ) {
                     Column(
                         modifier = Modifier
@@ -1849,95 +1965,38 @@ fun EduSchoolIndexedSelectScreen(
                         verticalArrangement = Arrangement.spacedBy(1.dp)
                     ) {
                         letters.forEachIndexed { index, letter ->
-                            val active = index == alphabetIndicatorProgress
-                                .roundToInt()
-                                .coerceIn(0, letters.lastIndex)
+                            // The blue highlight rides the spring-driven indicator, so it
+                            // glides nonlinearly between letters instead of snapping.
+                            val highlight = (1f - abs(
+                                index.toFloat() - alphabetIndicatorProgress
+                            )).coerceIn(0f, 1f)
                             Text(
                                 letter,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .clip(RoundedCornerShape(50))
-                                    .clickable {
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null
+                                    ) {
                                         haptic.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                                         sectionPositions[letter]?.let { position ->
                                             scope.launch { listState.animateScrollToItem(position) }
                                         }
                                     }
                                     .padding(horizontal = 4.dp, vertical = 1.dp),
-                                color = if (active) {
-                                    ComposeColor(0xFF0A84FF)
-                                } else {
-                                    sleepDownPanelForegroundColor(state.config).copy(
-                                        alpha = if (appUsesDarkTheme(state.config)) 0.52f else 0.68f
-                                    )
-                                },
+                                color = lerp(
+                                    sleepDownPanelForegroundColor(config).copy(
+                                        alpha = if (appUsesDarkTheme(config)) 0.52f else 0.68f
+                                    ),
+                                    ComposeColor(0xFF0A84FF),
+                                    highlight
+                                ),
                                 style = MaterialTheme.typography.labelSmall,
                                 fontWeight = FontWeight.SemiBold,
                                 textAlign = TextAlign.Center
                             )
                         }
-                    }
-                }
-            }
-            // The content slot is full-screen, so explicitly remove both the measured top-bar
-            // region and the complete search dock before centering the rail in the remaining area.
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(
-                        top = topPadding,
-                        bottom = alphabetRailBottomExclusion
-                    )
-                    .clipToBounds()
-            ) {
-                AnimatedVisibility(
-                    visible = showAlphabetRail,
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(end = 6.dp),
-                    enter = fadeIn(tween(240)),
-                    exit = fadeOut(tween(240))
-                ) {
-                    val railMotionProgress by transition.animateFloat(
-                        transitionSpec = { tween(240) },
-                        label = "edu-alphabet-motion"
-                    ) { state ->
-                        if (state == EnterExitState.Visible) 1f else 0f
-                    }
-                    val railTint = if (appUsesDarkTheme(state.config)) {
-                        ComposeColor(0xFF111318)
-                    } else {
-                        ComposeColor.White
-                    }
-                    Box(
-                        modifier = railModifier
-                            .width(alphabetRailWidth)
-                            .progressiveBackdropBlur(
-                                backdrop = overlayBackdrop,
-                                tintColor = railTint,
-                                blurRadius = 10.dp,
-                                tintIntensity = if (appUsesDarkTheme(state.config)) 0.10f else 0.22f,
-                                domain = GlassBackdropDomain.ChromeCombined,
-                                direction = ProgressiveBlurDirection.LeftToRight,
-                                topMaskFadeStart = 0.08f,
-                                topMaskFadeEnd = 1f,
-                                topTintFadeStart = 0.18f,
-                                topTintFadeEnd = 1f,
-                                fallbackTintStops = listOf(
-                                    0f to ComposeColor.Transparent,
-                                    0.42f to railTint.copy(alpha = 0.10f),
-                                    1f to railTint.copy(alpha = 0.44f)
-                                )
-                            )
-                            .graphicsLayer {
-                                compositingStrategy = CompositingStrategy.Offscreen
-                                renderEffect = platformBlurRenderEffect(
-                                    detailMotionBlurRadiusDp(railMotionProgress) * density.density
-                                )
-                            },
-                        contentAlignment = Alignment.CenterEnd
-                    ) {
-                        railContent()
                     }
                 }
             }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
@@ -154,12 +154,14 @@ open class AiEduImportProgressActivityHost : ComponentActivity() {
         @Suppress("DEPRECATION")
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
         val app = application as CourseScheduleApp
+        val taskId = intent.getStringExtra(AiImportTaskManager.EXTRA_TASK_ID)
+        AiImportForegroundService.clearCompletion(this, taskId)
         setContent {
             val state by app.repository.state.collectAsStateWithLifecycle(AppState())
             CourseScheduleTheme(config = state.config) {
                 AiEduImportProgressPage(
                     config = state.config,
-                    taskId = intent.getStringExtra(AiImportTaskManager.EXTRA_TASK_ID),
+                    taskId = taskId,
                     onImportSubmitted = { returnToScheduleHome() },
                     onScreenModeRequested = {
                         finish()
@@ -174,6 +176,15 @@ open class AiEduImportProgressActivityHost : ComponentActivity() {
                 )
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        AiImportForegroundService.clearCompletion(
+            this,
+            intent.getStringExtra(AiImportTaskManager.EXTRA_TASK_ID)
+        )
     }
 }
 
@@ -1287,6 +1298,7 @@ private fun AiEduAttachmentMorphOverlay(
             }
         }
     }
+
 }
 
 private const val AiAttachmentPreviewOpenDurationMillis = 430

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
@@ -139,7 +139,6 @@ import com.xiaomanjun.sleepdownschedule.transition.TransitionRouteId
 import com.xiaomanjun.sleepdownschedule.transition.attachOpeningSourceSnapshotHandoff
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
@@ -227,23 +226,30 @@ internal fun AiEduImportProgressPage(
 ) {
     val observedSessionProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
     val sessionPreviewDraft by AiEduImportProgressSession.previewDraft.collectAsStateWithLifecycle()
-    val sessionProgress = observedSessionProgress?.takeIf {
-        taskId.isNullOrBlank() || it.taskId == taskId
-    }
     val historicalMode = historicalProgress != null && historicalDraft != null
     var localProgress by remember(historicalProgress) { mutableStateOf(historicalProgress) }
     var localPreviewDraft by remember(historicalDraft) { mutableStateOf(historicalDraft) }
-    val current = if (historicalMode) {
+    var ownedRevisionTaskId by remember(historicalProgress) { mutableStateOf<String?>(null) }
+    val sessionProgress = observedSessionProgress?.takeIf {
+        taskId.isNullOrBlank() || it.taskId == taskId
+    }
+    val ownedRevisionProgress = observedSessionProgress?.takeIf {
+        ownedRevisionTaskId != null && it.taskId == ownedRevisionTaskId
+    }
+    val current = ownedRevisionProgress ?: if (historicalMode) {
         checkNotNull(localProgress ?: historicalProgress)
     } else {
         sessionProgress ?: AiEduImportProgress(steps = listOf("等待 AI 教务导入任务"))
     }
-    val previewDraft = if (historicalMode) localPreviewDraft else sessionPreviewDraft
+    val previewDraft = if (ownedRevisionProgress != null) {
+        sessionPreviewDraft
+    } else if (historicalMode) {
+        localPreviewDraft
+    } else {
+        sessionPreviewDraft
+    }
     fun updateProgress(next: AiEduImportProgress) {
         if (historicalMode) localProgress = next else AiEduImportProgressSession.update(next)
-    }
-    fun updatePreviewDraft(next: ImportDraft) {
-        if (historicalMode) localPreviewDraft = next else AiEduImportProgressSession.setPreviewDraft(next)
     }
     fun requestImport(draft: ImportDraft, createNewSchedule: Boolean) {
         onImportRequested?.invoke(draft, createNewSchedule)
@@ -321,8 +327,24 @@ internal fun AiEduImportProgressPage(
         hostConsumesImeResize = hostConsumesImeResize
     )
     val conversationScope = rememberCoroutineScope()
+    LaunchedEffect(
+        historicalMode,
+        ownedRevisionTaskId,
+        ownedRevisionProgress?.finished,
+        sessionPreviewDraft
+    ) {
+        val completed = ownedRevisionProgress
+        if (historicalMode && completed?.finished == true) {
+            localProgress = completed
+            sessionPreviewDraft?.let { localPreviewDraft = it }
+            ownedRevisionTaskId = null
+        }
+    }
     LaunchedEffect(current.finished) {
-        if (current.finished) executionExpanded = false
+        if (current.finished) {
+            executionExpanded = false
+            conversationSending = false
+        }
     }
     BackHandler(enabled = current.awaitingConfirmation) {
         AiEduImportProgressSession.cancel()
@@ -548,93 +570,16 @@ internal fun AiEduImportProgressPage(
                         } else {
                             val baseDraft = previewDraft ?: return@send
                             conversationSending = true
-                            conversationScope.launch {
-                                val settings = AiImportSettingsStore.loadForRuntime(context)
-                                    ?: AiImportSettingsStore.load(context)
-                                var workingProgress = current.copy(
-                                    steps = current.steps + listOf(
-                                        "正在理解你的新要求",
-                                        "模型正在分析课程、周次和节次"
-                                    ),
-                                    userPrompt = prompt,
-                                    liveSummary = "我正在理解你的修改要求，并核对现有课程、周次和节次信息。",
-                                    finished = false,
-                                    error = null
-                                )
-                                updateProgress(workingProgress)
-                                val progressTicker = launch {
-                                    listOf(
-                                        "模型正在核对现有课表结构",
-                                        "模型正在生成修改方案",
-                                        "仍在等待模型完成，请保留此页面"
-                                    ).forEach { summary ->
-                                        delay(2_400)
-                                        if (!workingProgress.finished) {
-                                            workingProgress = workingProgress.copy(
-                                                steps = workingProgress.steps + summary,
-                                                liveSummary = summary
-                                            )
-                                            updateProgress(workingProgress)
-                                        }
-                                    }
-                                }
-                                AiScheduleImportService(context)
-                                    .reviseSchedule(baseDraft, prompt, current, settings)
-                                    .mapCatching { result ->
-                                        val revised = ScheduleImportParser.parse(
-                                            result.output.ifBlank { result.rawOutput },
-                                            baseDraft.config
-                                        ).getOrThrow().copy(source = ImportDraftSource.AI_EDU)
-                                        revised to result
-                                    }
-                                    .onSuccess { (revised, result) ->
-                                        progressTicker.cancel()
-                                        val previousTurns = current.conversationTurns.ifEmpty {
-                                            listOf(
-                                                AiEduImportConversationTurn(
-                                                    userPrompt = current.userPrompt,
-                                                    reasoningOutput = current.reasoningOutput,
-                                                    aiOutput = current.aiOutput
-                                                )
-                                            )
-                                        }
-                                        val nextProgress = workingProgress.copy(
-                                            steps = workingProgress.steps + listOf("模型已给出修改摘要", "修改结果通过本地校验"),
-                                            userPrompt = prompt,
-                                            requestSent = true,
-                                            reasoningOutput = result.reasoningOutput,
-                                            aiOutput = result.rawOutput,
-                                            liveSummary = result.reasoningOutput.ifBlank {
-                                                "本轮已按你的要求更新课表，并通过本地校验。"
-                                            },
-                                            finished = true,
-                                            error = null,
-                                            conversationTurns = previousTurns + AiEduImportConversationTurn(
-                                                userPrompt = prompt,
-                                                reasoningOutput = result.reasoningOutput,
-                                                aiOutput = result.rawOutput
-                                            )
-                                        )
-                                        updatePreviewDraft(revised)
-                                        updateProgress(nextProgress)
-                                        if (historicalEntryId != null) {
-                                            AiImportHistoryStore.update(context, historicalEntryId, revised, nextProgress)
-                                        } else {
-                                            AiImportHistoryStore.updateMatching(context, baseDraft, revised, nextProgress)
-                                        }
-                                    }
-                                    .onFailure { error ->
-                                        progressTicker.cancel()
-                                        updateProgress(
-                                            workingProgress.copy(
-                                                steps = workingProgress.steps + "本次修改未完成",
-                                                finished = true,
-                                                error = error.message ?: "AI 没有完成这次修改"
-                                            )
-                                        )
-                                    }
-                                conversationSending = false
-                            }
+                            val settings = AiImportSettingsStore.loadForRuntime(context)
+                                ?: AiImportSettingsStore.load(context)
+                            ownedRevisionTaskId = AiImportTaskManager.startRevision(
+                                context = context,
+                                baseDraft = baseDraft,
+                                instruction = prompt,
+                                baseProgress = current,
+                                settings = settings,
+                                historicalEntryId = historicalEntryId
+                            )
                         }
                     }
                 )

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
@@ -160,6 +160,7 @@ open class AiEduImportProgressActivityHost : ComponentActivity() {
             CourseScheduleTheme(config = state.config) {
                 AiEduImportProgressPage(
                     config = state.config,
+                    taskId = intent.getStringExtra(AiImportTaskManager.EXTRA_TASK_ID),
                     onImportSubmitted = { returnToScheduleHome() },
                     onScreenModeRequested = {
                         finish()
@@ -214,6 +215,7 @@ internal fun aiComposerBottomInsetPx(
 internal fun AiEduImportProgressPage(
     config: ScheduleConfigEntity,
     onClose: () -> Unit,
+    taskId: String? = null,
     onImportSubmitted: () -> Unit = onClose,
     onScreenModeRequested: () -> Unit = AiEduImportProgressSession::useScreenMode,
     historicalProgress: AiEduImportProgress? = null,
@@ -223,8 +225,11 @@ internal fun AiEduImportProgressPage(
     hostConsumesImeResize: Boolean = false,
     onImportRequested: ((ImportDraft, Boolean) -> Unit)? = null
 ) {
-    val sessionProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
+    val observedSessionProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
     val sessionPreviewDraft by AiEduImportProgressSession.previewDraft.collectAsStateWithLifecycle()
+    val sessionProgress = observedSessionProgress?.takeIf {
+        taskId.isNullOrBlank() || it.taskId == taskId
+    }
     val historicalMode = historicalProgress != null && historicalDraft != null
     var localProgress by remember(historicalProgress) { mutableStateOf(historicalProgress) }
     var localPreviewDraft by remember(historicalDraft) { mutableStateOf(historicalDraft) }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/progress/AiEduImportProgressUi.kt
@@ -33,7 +33,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.AnimationVector1D
-import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
@@ -93,9 +93,7 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Offset
@@ -349,15 +347,6 @@ internal fun AiEduImportProgressPage(
                     val zoom = previewBackgroundZoom.value
                     scaleX = zoom
                     scaleY = zoom
-                    val depthProgress = (
-                        (zoom - 1f) / (HomeAnchoredMorphBackgroundScale - 1f)
-                        ).coerceIn(0f, 1f)
-                    val blurPx = 12.dp.toPx() * depthProgress
-                    renderEffect = if (blurPx > 0.01f) {
-                        BlurEffect(blurPx, blurPx, TileMode.Clamp)
-                    } else {
-                        null
-                    }
                 }
         ) {
             Box(Modifier.fillMaxSize().glassBackdropProducer(previewSceneBackdrop)) {
@@ -1182,52 +1171,52 @@ private fun AiEduAttachmentMorphOverlay(
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
     val progress = remember(request) { Animatable(0f) }
+    val contentAlpha = remember(request) { Animatable(0f) }
     var closing by remember(request) { mutableStateOf(false) }
+    var contentMounted by remember(request) { mutableStateOf(false) }
     val target = Rect(0f, 0f, rootSize.width.toFloat(), rootSize.height.toFloat())
     val screenCornerRadiusPx = deviceScreenCornerRadiusPx()
-    val geometry = homeAnchoredMorphGeometry(
-        source = request.sourceBounds,
-        target = target,
-        rawProgress = progress.value,
-        closing = closing,
-        // A document preview is a direct card-to-page expansion. The droplet/pinch trajectory
-        // used by Home menu destinations made this short vertical transition visibly change
-        // direction; use the same reversible direct geometry for opening and closing instead.
-        directClosing = true,
-        sourceCornerRadiusPx = with(density) { 20.dp.toPx() },
-        pinchDiameterPx = with(density) { 44.dp.toPx() },
-        minimumDropPx = with(density) { 10.dp.toPx() },
-        maximumDropPx = with(density) { 54.dp.toPx() },
-        maximumArcPx = with(density) { 46.dp.toPx() },
-        targetCornerRadiusPx = screenCornerRadiusPx
+    val morphProgress = progress.value.coerceIn(0f, 1f)
+    val source = request.sourceBounds
+    val rect = Rect(
+        left = source.left + (target.left - source.left) * morphProgress,
+        top = source.top + (target.top - source.top) * morphProgress,
+        right = source.right + (target.right - source.right) * morphProgress,
+        bottom = source.bottom + (target.bottom - source.bottom) * morphProgress
     )
-    val fullyOpen = !closing && progress.value >= 0.999f
-    val renderedCornerRadiusPx = if (fullyOpen) 0f else geometry.cornerRadiusPx
-    val sourceBlurPx = with(density) { 5.dp.toPx() } * homeMorphSmoothStep(
-        0f,
-        0.34f,
-        geometry.pathProgress
-    )
-    val contentBlurPx = with(density) { 5.dp.toPx() } * (
-        1f - homeMorphSmoothStep(0.42f, 0.98f, geometry.expansionProgress)
-    )
+    val sourceHandoff = aiAttachmentPreviewSmoothStep(0.06f, 0.32f, morphProgress)
+    val sourceAlpha = 1f - sourceHandoff
+    val sourceScale = 1f - 0.018f * sourceHandoff
+    val sourceCornerRadiusPx = with(density) { 20.dp.toPx() }
+    val cornerRadiusPx = sourceCornerRadiusPx +
+        (screenCornerRadiusPx - sourceCornerRadiusPx) * morphProgress
+    val fullyOpen = morphProgress >= 0.999f
+    val renderedCornerRadiusPx = if (fullyOpen) 0f else cornerRadiusPx
+    val shellColor = if (appUsesDarkTheme(config)) Color(0xFF202124) else Color(0xFFF7F7F8)
     fun dismiss() {
         if (!closing) {
             closing = true
             scope.launch {
+                if (contentMounted) {
+                    contentAlpha.animateTo(0f, tween(90))
+                    contentMounted = false
+                }
                 coroutineScope {
                     launch {
                         progress.animateTo(
                             0f,
-                            tween(HomeAnchoredMorphCloseDurationMillis, easing = LinearEasing)
+                            tween(
+                                AiAttachmentPreviewCloseDurationMillis,
+                                easing = AiAttachmentPreviewCloseEasing
+                            )
                         )
                     }
                     launch {
                         backgroundZoom.animateTo(
                             1f,
                             tween(
-                                HomeAnchoredMorphBackgroundDurationMillis,
-                                easing = HomeAnchoredBackgroundEasing
+                                AiAttachmentPreviewBackgroundDurationMillis,
+                                easing = AiAttachmentPreviewCloseEasing
                             )
                         )
                     }
@@ -1246,67 +1235,61 @@ private fun AiEduAttachmentMorphOverlay(
             launch {
                 progress.animateTo(
                     1f,
-                    tween(HomeAnchoredMorphOpenDurationMillis, easing = LinearEasing)
+                    tween(
+                        AiAttachmentPreviewOpenDurationMillis,
+                        easing = AiAttachmentPreviewOpenEasing
+                    )
                 )
             }
             launch {
                 backgroundZoom.animateTo(
-                    HomeAnchoredMorphBackgroundScale,
+                    AiAttachmentPreviewBackgroundScale,
                     tween(
-                        HomeAnchoredMorphBackgroundDurationMillis,
-                        delayMillis = HomeAnchoredMorphBackgroundDelayMillis,
-                        easing = HomeAnchoredBackgroundEasing
+                        AiAttachmentPreviewBackgroundDurationMillis,
+                        delayMillis = 24,
+                        easing = AiAttachmentPreviewOpenEasing
                     )
                 )
             }
+        }
+        if (!closing) {
+            contentMounted = true
+            contentAlpha.snapTo(0f)
+            contentAlpha.animateTo(1f, tween(100))
         }
     }
     BackHandler(onBack = ::dismiss)
     Box(
         Modifier
             .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.34f * geometry.expansionProgress))
+            .background(Color.Black.copy(alpha = 0.34f * morphProgress))
             .clickable(onClick = ::dismiss)
     )
     Box(
         Modifier
-            .offset { IntOffset(geometry.rect.left.roundToInt(), geometry.rect.top.roundToInt()) }
+            .offset { IntOffset(rect.left.roundToInt(), rect.top.roundToInt()) }
             .size(
-                with(density) { geometry.rect.width.toDp() },
-                with(density) { geometry.rect.height.toDp() }
+                with(density) { rect.width.toDp() },
+                with(density) { rect.height.toDp() }
             )
-             .graphicsLayer {
-                 clip = !fullyOpen
-                 shape = RoundedCornerShape(with(density) { renderedCornerRadiusPx.toDp() })
-                 compositingStrategy = if (fullyOpen) {
-                     CompositingStrategy.Auto
-                 } else {
-                     CompositingStrategy.Offscreen
-                 }
-             }
+            .graphicsLayer {
+                clip = !fullyOpen
+                shape = RoundedCornerShape(with(density) { renderedCornerRadiusPx.toDp() })
+            }
+            .background(
+                color = shellColor,
+                shape = RoundedCornerShape(with(density) { renderedCornerRadiusPx.toDp() })
+            )
             .clickable(enabled = false) {}
     ) {
-        AiEduLiquidPanel(
-            backdrop = backdrop,
-            config = config,
-            modifier = Modifier
-                .fillMaxSize()
-                .graphicsLayer { alpha = geometry.surfaceAlpha.coerceAtLeast(0.08f) },
-            accent = Color(0xFF8E8E93),
-            shape = RoundedCornerShape(with(density) { renderedCornerRadiusPx.toDp() })
-        ) { }
-        if (geometry.sourceAlpha > 0.01f) {
+        if (sourceAlpha > 0.01f) {
             Box(
                 Modifier
                     .fillMaxSize()
                     .graphicsLayer {
-                        alpha = geometry.sourceAlpha
-                        scaleX = geometry.sourceScale
-                        scaleY = geometry.sourceScale
-                        compositingStrategy = CompositingStrategy.Offscreen
-                        renderEffect = if (sourceBlurPx > 0.01f) {
-                            BlurEffect(sourceBlurPx, sourceBlurPx, TileMode.Clamp)
-                        } else null
+                        alpha = sourceAlpha
+                        scaleX = sourceScale
+                        scaleY = sourceScale
                     }
             ) {
                 AiEduAttachmentCardContent(
@@ -1316,38 +1299,56 @@ private fun AiEduAttachmentMorphOverlay(
                 )
             }
         }
-        if (geometry.contentAlpha > 0.01f) {
-            Column(
-                Modifier
+        if (contentMounted) {
+            AiEduLiquidPanel(
+                backdrop = backdrop,
+                config = config,
+                modifier = Modifier
                     .fillMaxSize()
-                    .graphicsLayer {
-                        alpha = geometry.contentAlpha
-                        compositingStrategy = CompositingStrategy.Offscreen
-                        renderEffect = if (contentBlurPx > 0.01f) {
-                            BlurEffect(contentBlurPx, contentBlurPx, TileMode.Clamp)
-                        } else null
-                    }
-                    .padding(top = 34.dp, start = 16.dp, end = 16.dp, bottom = 18.dp)
+                    .graphicsLayer { alpha = contentAlpha.value },
+                accent = Color(0xFF8E8E93),
+                shape = RoundedCornerShape(0.dp)
             ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(request.attachment.title, modifier = Modifier.weight(1f), color = textColor, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
-                    Text("完成", modifier = Modifier.clickable(onClick = ::dismiss).padding(12.dp), color = Color(0xFF0A84FF), fontWeight = FontWeight.SemiBold)
-                }
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(vertical = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                Column(
+                    Modifier
+                        .fillMaxSize()
+                        .padding(top = 34.dp, start = 16.dp, end = 16.dp, bottom = 18.dp)
                 ) {
-                    if (request.attachment.text.isNotBlank()) item {
-                        Text(request.attachment.text, color = textColor.copy(alpha = 0.88f), style = MaterialTheme.typography.bodyMedium, lineHeight = 21.sp)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(request.attachment.title, modifier = Modifier.weight(1f), color = textColor, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
+                        Text("完成", modifier = Modifier.clickable(onClick = ::dismiss).padding(12.dp), color = Color(0xFF0A84FF), fontWeight = FontWeight.SemiBold)
                     }
-                    itemsIndexed(request.attachment.images) { index, image ->
-                        AiEduPreviewImage(image, "第 ${index + 1} 页")
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        if (request.attachment.text.isNotBlank()) item(key = "attachment-text") {
+                            Text(request.attachment.text, color = textColor.copy(alpha = 0.88f), style = MaterialTheme.typography.bodyMedium, lineHeight = 21.sp)
+                        }
+                        itemsIndexed(
+                            items = request.attachment.images,
+                            key = { _, image -> image.pageIndex }
+                        ) { index, image ->
+                            AiEduPreviewImage(image, "第 ${index + 1} 页")
+                        }
                     }
                 }
             }
         }
     }
+}
+
+private const val AiAttachmentPreviewOpenDurationMillis = 430
+private const val AiAttachmentPreviewCloseDurationMillis = 360
+private const val AiAttachmentPreviewBackgroundDurationMillis = 280
+private const val AiAttachmentPreviewBackgroundScale = 1.04f
+private val AiAttachmentPreviewOpenEasing = CubicBezierEasing(0.20f, 0f, 0f, 1f)
+private val AiAttachmentPreviewCloseEasing = CubicBezierEasing(0.40f, 0f, 0.20f, 1f)
+
+private fun aiAttachmentPreviewSmoothStep(start: Float, end: Float, value: Float): Float {
+    val normalized = ((value - start) / (end - start)).coerceIn(0f, 1f)
+    return normalized * normalized * (3f - 2f * normalized)
 }
 
 @Composable

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/settings/SettingsUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/settings/SettingsUi.kt
@@ -812,6 +812,7 @@ fun AiImportSettingsSection(
         apiKey = apiKey
     )
     fun reload() {
+        message = null
         saved = AiImportSettingsStore.load(context)
         selectedProviderId = saved.profile.id
         customProviderName = saved.profile.displayName
@@ -839,11 +840,14 @@ fun AiImportSettingsSection(
 	}
     LaunchedEffect(
         remoteConfigState.bootstrap?.ai?.configVersion,
-        remoteConfigState.bootstrap?.ai?.enabled
+        remoteConfigState.bootstrap?.ai?.enabled,
+        remoteConfigState.bootstrap?.ai?.keyId,
+        remoteConfigState.bootstrap?.ai?.message
     ) {
         if (isManagedFreeProvider) reload()
     }
     fun selectProvider(providerId: String) {
+        message = null
         // Preserve the current provider draft before switching. In particular, the
         // custom compatible endpoint must not fall back to its empty preset whenever
         // the user temporarily selects another provider.

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/settings/SettingsUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/settings/SettingsUi.kt
@@ -999,7 +999,7 @@ fun AiImportSettingsSection(
                     SettingsGroup(backdrop = backdrop, config = state.config, modifier = Modifier.fillMaxWidth()) {
             SettingsInfoRow(
                 "每日免费 AI",
-                "每天由 SleepDown 提供共享免费额度，不保存明文 Key。${SleepDownRemoteConfig.managedFreeStatusMessage(context)}"
+                SleepDownRemoteConfig.managedFreeStatusMessage(context)
             )
 			SettingsActionRow(
 				title = "远程配置",

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/update/AppUpdate.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/update/AppUpdate.kt
@@ -11,7 +11,9 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Icon
 import android.net.Uri
+import android.os.Build
 import android.os.IBinder
 import android.provider.Settings
 import androidx.core.content.ContextCompat
@@ -414,20 +416,38 @@ class UpdateDownloadForegroundService : Service() {
             packageManager.getLaunchIntentForPackage(packageName) ?: Intent(this, MainActivity::class.java),
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-        return Notification.Builder(this, CHANNEL_ID)
+        val builder = Notification.Builder(this, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_download)
             .setContentTitle("正在下载更新")
             .setContentText(if (progress == null) name else "$name · $progress%")
             .setContentIntent(openApp)
-            .setProgress(100, progress ?: 0, progress == null)
             .setOngoing(true)
             .setOnlyAlertOnce(true)
             .setShowWhen(false)
             .setCategory(Notification.CATEGORY_PROGRESS)
             .setColor(0xFF0A84FF.toInt())
             .requestPromotedOngoing(if (progress == null) "下载中" else "$progress%")
-            .build()
+        if (Build.VERSION.SDK_INT >= 36) {
+            builder.setStyle(downloadProgressStyle(progress))
+        } else {
+            builder.setProgress(100, progress ?: 0, progress == null)
+        }
+        return builder.build()
     }
+
+    @Suppress("NewApi")
+    private fun downloadProgressStyle(progress: Int?): Notification.ProgressStyle =
+        Notification.ProgressStyle()
+            .setStyledByProgress(true)
+            .setProgressSegments(
+                listOf(
+                    Notification.ProgressStyle.Segment(100)
+                        .setColor(0xFF0A84FF.toInt())
+                )
+            )
+            .setProgress(progress ?: 0)
+            .setProgressIndeterminate(progress == null)
+            .setProgressTrackerIcon(Icon.createWithResource(this, R.drawable.ic_download))
 
     private fun completedNotification(name: String, apk: File): Notification {
         val uri = FileProvider.getUriForFile(this, "$packageName.fileprovider", apk)
@@ -469,7 +489,7 @@ class UpdateDownloadForegroundService : Service() {
     private fun createChannel() {
         val manager = getSystemService(NotificationManager::class.java)
         manager.createNotificationChannel(
-            NotificationChannel(CHANNEL_ID, "应用更新", NotificationManager.IMPORTANCE_LOW).apply {
+            NotificationChannel(CHANNEL_ID, "应用更新", NotificationManager.IMPORTANCE_DEFAULT).apply {
                 description = "显示应用更新包的下载进度"
                 setShowBadge(false)
             }
@@ -490,7 +510,7 @@ class UpdateDownloadForegroundService : Service() {
         const val EXTRA_TAG = "update_tag"
         const val EXTRA_NAME = "update_name"
         const val EXTRA_APK_NAME = "update_apk_name"
-        private const val CHANNEL_ID = "app_update_download"
+        private const val CHANNEL_ID = "app_update_live_progress"
         private const val NOTIFICATION_ID = 20260720
     }
 }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/update/AppUpdate.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/update/AppUpdate.kt
@@ -11,7 +11,6 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
-import android.graphics.drawable.Icon
 import android.net.Uri
 import android.os.Build
 import android.os.IBinder
@@ -447,7 +446,7 @@ class UpdateDownloadForegroundService : Service() {
             )
             .setProgress(progress ?: 0)
             .setProgressIndeterminate(progress == null)
-            .setProgressTrackerIcon(Icon.createWithResource(this, R.drawable.ic_download))
+            .setProgressTrackerIcon(whiteDotProgressTrackerIcon(this))
 
     private fun completedNotification(name: String, apk: File): Notification {
         val uri = FileProvider.getUriForFile(this, "$packageName.fileprovider", apk)
@@ -465,10 +464,19 @@ class UpdateDownloadForegroundService : Service() {
             .setContentTitle("更新下载完成")
             .setContentText("点击安装 $name")
             .setContentIntent(install)
-            .setAutoCancel(true)
+            .setOngoing(true)
             .setOnlyAlertOnce(true)
+            .setShowWhen(false)
             .setCategory(Notification.CATEGORY_STATUS)
             .setColor(0xFF0A84FF.toInt())
+            .requestPromotedOngoing("待安装")
+            .let { builder ->
+                if (Build.VERSION.SDK_INT >= 36) {
+                    builder.setStyle(downloadProgressStyle(100))
+                } else {
+                    builder.setProgress(100, 100, false)
+                }
+            }
             .build()
     }
 

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/glass/ui/ProgressiveBlur.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/glass/ui/ProgressiveBlur.kt
@@ -8,8 +8,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -26,7 +28,8 @@ enum class ProgressiveBlurDirection {
     TopToBottom,
     BottomToTop,
     LeftToRight,
-    RightToLeft
+    RightToLeft,
+    RailThreeWay
 }
 
 @Composable
@@ -114,6 +117,17 @@ fun Modifier.progressiveBackdropBlur(
             }
         )
     } else {
+        if (direction == ProgressiveBlurDirection.RailThreeWay) {
+            return drawWithCache {
+                val radius = maxOf(size.width, size.height * 0.58f)
+                val brush = Brush.radialGradient(
+                    *fallbackTintStops.toTypedArray(),
+                    center = Offset(size.width, size.height / 2f),
+                    radius = radius
+                )
+                onDrawBehind { drawRect(brush) }
+            }
+        }
         val brush = when (direction) {
             ProgressiveBlurDirection.TopToBottom -> Brush.verticalGradient(*fallbackTintStops.toTypedArray())
             ProgressiveBlurDirection.BottomToTop -> Brush.verticalGradient(
@@ -123,6 +137,7 @@ fun Modifier.progressiveBackdropBlur(
             ProgressiveBlurDirection.RightToLeft -> Brush.horizontalGradient(
                 *fallbackTintStops.map { (stop, color) -> 1f - stop to color }.reversed().toTypedArray()
             )
+            ProgressiveBlurDirection.RailThreeWay -> error("Handled above")
         }
         background(brush)
     }
@@ -148,6 +163,18 @@ internal fun progressiveBlurShaderSource(direction: ProgressiveBlurDirection): S
         ProgressiveBlurDirection.RightToLeft -> """
             float mask = 1.0 - smoothstep(maskFadeStart, maskFadeEnd, x);
             float tintMask = 1.0 - smoothstep(tintFadeStart, tintFadeEnd, x);
+        """.trimIndent()
+
+        ProgressiveBlurDirection.RailThreeWay -> """
+            float horizontalMask = smoothstep(maskFadeStart, maskFadeEnd, x);
+            float topMask = smoothstep(0.0, 0.14, y);
+            float bottomMask = 1.0 - smoothstep(0.86, 1.0, y);
+            float mask = horizontalMask * topMask * bottomMask;
+
+            float tintHorizontalMask = smoothstep(tintFadeStart, tintFadeEnd, x);
+            float tintTopMask = smoothstep(0.02, 0.18, y);
+            float tintBottomMask = 1.0 - smoothstep(0.82, 0.98, y);
+            float tintMask = tintHorizontalMask * tintTopMask * tintBottomMask;
         """.trimIndent()
     }
     return """

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/glass/ui/ProgressiveBlur.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/glass/ui/ProgressiveBlur.kt
@@ -37,6 +37,7 @@ fun ProgressiveBackdropBlur(
     height: Dp,
     blurRadius: Dp = 12.dp,
     tintIntensity: Float = 0.18f,
+    domain: GlassBackdropDomain = GlassBackdropDomain.Content,
     direction: ProgressiveBlurDirection = ProgressiveBlurDirection.TopToBottom,
     topMaskFadeStart: Float = 0.45f,
     topMaskFadeEnd: Float = 1f,
@@ -53,6 +54,7 @@ fun ProgressiveBackdropBlur(
                 tintColor = tintColor,
                 blurRadius = blurRadius,
                 tintIntensity = tintIntensity,
+                domain = domain,
                 direction = direction,
                 topMaskFadeStart = topMaskFadeStart,
                 topMaskFadeEnd = topMaskFadeEnd,
@@ -69,6 +71,7 @@ fun Modifier.progressiveBackdropBlur(
     tintColor: Color,
     blurRadius: Dp = 12.dp,
     tintIntensity: Float = 0.18f,
+    domain: GlassBackdropDomain = GlassBackdropDomain.Content,
     direction: ProgressiveBlurDirection = ProgressiveBlurDirection.TopToBottom,
     topMaskFadeStart: Float = 0.45f,
     topMaskFadeEnd: Float = 1f,
@@ -84,7 +87,7 @@ fun Modifier.progressiveBackdropBlur(
         }
         val descriptor = rememberGlassSurfaceDescriptor(
             debugLabel = "ProgressiveBackdropBlur",
-            domain = GlassBackdropDomain.Content,
+            domain = domain,
             materialRole = GlassMaterialRole.SimpleBlur,
             sceneKey = "progressive-backdrop-blur"
         )

--- a/docs/architecture/DAY_AGENT_RUNTIME.md
+++ b/docs/architecture/DAY_AGENT_RUNTIME.md
@@ -8,6 +8,8 @@
 2. `ToolDecisionStage`：只负责本轮工具选择，要求把当前可判断且互相独立的读取放在同一响应并行发出。
 3. `FinalAnswerStage`：工具阶段结束后才附带完整 `<agent_actions>` 写入协议和 JSON 示例。
 
+普通本地工具决策最多进行 3 轮：第一轮并行读取独立事实，第二轮补充依赖事实，第三轮收敛并进入最终回答。若新一轮没有新增事实版本、查询或工具结果，立即结束循环。MiMo `web_search` 的一次强制重试属于同一供应商搜索请求，不占用本地工具轮次。
+
 完整写入协议不再随每一次工具判断重复发送。以本次源码字符数为基准，稳定 `ChatSystem` 从 4632 字符缩至 630 字符；整个提示词文件从 5846 字符缩至 3920 字符。这里是静态字符对比，不等同于供应商实际 token 或延迟收益。
 
 ## 工具生命周期
@@ -20,6 +22,10 @@
 | 外部公开事实 | MiMo `web_search` | 仅官方支持端点提供，不替代本地课表事实 |
 
 相同工具和规范化参数在同一用户回合再次出现时，不再重复序列化完整结果，而是返回事实版本一致的复用提示。每个 provider 仍收到与自己 `call_id` 对应的合法结果，Chat Completions 与 Responses 两条链路遵守相同策略。
+
+Chat Completions 只保留最近一轮完整的 assistant/tool 协议配对；更早且已经闭合的工具轮压成带 `sourceHash` 的结构化事实块，删除重复规划说明，但不产生孤立的 tool 消息。学期课表共享课表与学期元信息，课程按紧凑行输出，空地点、空教师和默认 `ALL` 单双周不重复占用上下文。
+
+Responses 使用 `store=false` 时继续完整重放模型返回的 output items，包括 opaque reasoning items；不能用 Chat 路径的压缩方式删除这些项目。Responses 工具决策采用供应商支持的 `minimal`，不支持时采用 `low`，最终回答继续使用用户当前 reasoning effort。
 
 MiMo 联网搜索属于供应商服务端插件，不属于 SleepDown 本地函数工具。只有官方 MiMo 端点与支持的模型可以启用该类型；若模型先返回函数形态的 `web_search` 意图，解析层将其识别为供应商搜索请求而不是“未知本地工具”，随后最多重试一次并把同一请求的 `force_search` 设为 `true`。只有响应中的 `annotations`、`usage.web_search_usage` 或搜索后的正文才算真实搜索证据；结果以 `provider_web_search_result`、`untrusted_external_data` 身份进入最终回答阶段，不能取得系统指令或本地课表事实的权限。其他未知工具名仍然立即报错，不能因为兼容 MiMo 而被吞掉。
 
@@ -41,5 +47,9 @@ MiMo 联网搜索属于供应商服务端插件，不属于 SleepDown 本地函�
 - 课程自由文本、长期记忆和工具内容都是数据，不是指令。
 - 工具阶段不生成最终计划；最终阶段不再提供原生工具，防止把写入原语误当函数调用。
 - 写入仍由 `<agent_actions>` 交给本地预演、确认、事务执行和回读验证，模型不得提前宣称完成。
+
+## 轻量遥测
+
+每个用户回合结束时通过 `DayAgentMetrics` 记录决策轮数、每轮工具调用数、总请求数、工具结果字符数、输入/输出 token、缓存输入 token、reasoning token 和最终回答延迟。token 字段仅在供应商响应提供 usage 时累加，不落库，也不记录课程正文或用户问题。
 
 相关回归测试位于 `feature/agent/AgentToolsTest.kt`，覆盖工具 schema 动态收窄、缓存键稳定性、提示词分段、provider 协议形状，以及 MiMo `web_search` 意图与本地未知工具的分流。


### PR DESCRIPTION
## 完成

- Alert Dialog 单行按钮布局统一纵向压缩
- COLORFUL 模式下单节课编辑支持课程颜色，并显示课程当前实际颜色
- 新增可复用 CourseColorPicker，接入单节课编辑与课程管理颜色入口
- 首页周视图末行缩放浮标回到课程网格层级，不再用 Window Popup 覆盖 Dock
- AI 文件预览使用独立 cubic 与 shell-first Morph，完成展开后再挂载文档内容
- AI Import 任务由 `CourseScheduleApp.applicationScope` 持有，UI 仅按 taskId 观察
- 普通文本、文件、图片、CapturedPage 和 AI 修订统一进入同一 HTTP 执行链
- 请求状态按真实边界更新：BODY_WRITE_START 后“正在上传材料”，BODY_WRITE_END 后“已发送给 AI”，首个 SSE 事件/非流式读取后“AI 正在解析课程”
- Chat Completions 使用 BufferedReader 逐行消费 SSE，并增量聚合 content、reasoning、finish_reason、tool call 名称与 arguments
- Responses 请求启用流式并逐事件消费；保留 completed response、function call、structured output 与 reasoning
- 每个 AI 请求记录 requestId、provider、endpoint、host/path、inputType、bodyBytes、图片/截图数、phase、耗时和失败异常链
- AI Import 与 Day Agent 删除所有伪 ProgressStyle、tracker 和旧系统假进度，只保留真实状态文字及 promoted ongoing
- AI Import 完成后保留“课表解析完成 · 发现 X 门课程”的待查看实时活动，进入对应任务后清除
- Update Download 独占真实 ProgressStyle；进度来自 downloadedBytes / totalBytes，保留白色圆点 tracker 与待安装完成态
- 教务字母栏拆分固定 96dp Blur Veil 与可交互 Alphabet Content；blur/tint 使用 LEFT × TOP × BOTTOM 三向乘积 mask，上下各留 32dp fade envelope
- 首页左上双行日期标题移出 TopAppBar.title，改为 66dp 根层自然高度兄弟节点；移除固定 42dp 与动态字体缩放，保留右侧按钮避让和自然点击范围
- Day Agent 工具轮次、上下文、reasoning effort 与轻量 usage telemetry 优化
- AI 设置页按后端当前发布文案显示；新版本上报设备厂商供控制台归类

## 网络链路说明

- 请求 body 先完整构造，再用固定长度 streaming mode 写入；不会在写入前误报“已发送”。
- Chat Completions 与 Day Agent 一样逐行读取 `data:`，不再等待整个 SSE EOF 后一次性解析。
- Chat SSE 聚合结果仍还原为现有 parser 接受的普通 completion JSON，因此 scheduleImportChatTool、tool_choice、修订二轮调用和现有解析器不变。
- Responses 逐事件消费并优先使用 `response.completed` 的完整 response；服务实际返回普通 JSON content-type 时直接读取该响应，不进行协议重试。
- 不对超时、DNS、connection reset 或 socket 错误做非流式 fallback。
- 进程被系统杀死后的 provider 请求恢复不在本轮承诺范围。

## 验证

- `compileGithubReleaseKotlin`：通过
- `assembleGithubRelease`：通过（R8、资源压缩、lintVital、签名、打包）
- APK：`1.2.2 (28)`，包名 `com.xiaomanjun.sleepdownschedule`
- APK SHA-256：`D6442DBECFD60AAD7C97F1AF79A3EBEFD3A036A22CF0BE815580A4DBCB254831`
- 当前未检测到已连接 Android 设备，因此本轮未覆盖安装，也未执行 AI Import / Day Agent 前后台实机复现

## 必须实机确认

- AI 文本小请求经过 REQUEST_CREATED → BODY_WRITE_START → BODY_WRITE_END → HEADERS_RECEIVED → FIRST_EVENT/STREAM_END，切 Home 后完成
- CapturedPage DOM + 多截图大请求在上传/等待阶段切 Home 后完成；失败时记录 failedAt、exception class、message 与 cause
- Day Agent 切 Home 后仍能回复，通知无进度条且状态文字正常
- AI Import 运行态无进度条，完成后待查看实时活动可点击且进入页面后清除
- Android 16 更新下载保留真实 ProgressStyle 与白色圆点 tracker
- 教务字母栏 veil 向左、向上、向下自然消散，触摸范围仍只属于字母内容
- 首页双行标题在系统字体 100% / 130% / 150%、不同显示大小和问题 OEM 字体下无底部裁切，并且不与右侧按钮碰撞
- 末行缩放浮标与 Dock、颜色入口、附件预览轨迹等既有 PR 验收项

## 明确未做

- WorkManager、第二套 wakelock、守护 Service、轮询保活或产品级网络重试
- 进程死亡后的完整请求恢复平台
- 课程管理首页瀑布流或卡片重设计
- Widget、WebView、MIUIX Popup、Room migration、ViewSeamless 重构
- 后端修改
