### PR TITLE
修复主题图标刷新并支持拾光适配在线更新

### DIFF
--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/CourseScheduleApp.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/CourseScheduleApp.kt
@@ -61,6 +61,10 @@ class CourseScheduleApp : Application() {
             }
 
             override fun onStop(owner: LifecycleOwner) {
+                // Some ColorOS/Oplus launchers remove the visible task when a launcher alias is
+                // changed during an Activity return/theme handoff. Appearance changes record the
+                // desired alias immediately, then publish it only after the process is backgrounded.
+                AppIconManager.applyStoredMode(this@CourseScheduleApp)
                 if (hideFromRecentsEnabled) setTaskExcludedFromRecents(true)
             }
         })

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/MainActivity.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/MainActivity.kt
@@ -135,13 +135,12 @@ fun CourseScheduleTheme(
     val darkTheme = appUsesDarkTheme(config)
     val view = LocalView.current
     LaunchedEffect(config.followSystemDarkMode, darkTheme, view.context) {
-        // Changing launcher aliases from a secondary settings Activity can make
-        // ColorOS/Oplus remove the visible task. Apply icon changes only from the
-        // main Activity; settings still update their theme immediately and the
-        // launcher alias catches up when the user returns home.
+        // Changing launcher aliases during the settings-to-home handoff can make ColorOS/Oplus
+        // remove the visible task. Record the desired appearance here; CourseScheduleApp applies
+        // the alias only after the whole process enters the background.
         if (view.context is MainActivity) {
             AppIconManager.syncAppearance(
-                context = view.context,
+                context = view.context.applicationContext,
                 followsSystemDarkMode = config.followSystemDarkMode,
                 darkTheme = darkTheme
             )

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -25,6 +25,7 @@ import com.xiaomanjun.sleepdownschedule.core.wallpaper.*
 import com.xiaomanjun.sleepdownschedule.domain.course.*
 import com.xiaomanjun.sleepdownschedule.feature.course.editor.*
 import com.xiaomanjun.sleepdownschedule.feature.importing.*
+import com.xiaomanjun.sleepdownschedule.feature.importing.shiguang.ShiguangWarehouseUpdater
 
 import com.xiaomanjun.sleepdownschedule.core.identity.AppDistribution
 import com.xiaomanjun.sleepdownschedule.feature.backup.*
@@ -6893,6 +6894,47 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                 factory = ScheduleViewModelFactory(app, app.repository)
             )
             val state by viewModel.state.collectAsStateWithLifecycle()
+            val refreshScope = rememberCoroutineScope()
+            var warehouseGeneration by remember { mutableIntStateOf(0) }
+            var warehouseRefreshing by remember { mutableStateOf(false) }
+            fun refreshWarehouse(manual: Boolean) {
+                if (warehouseRefreshing) return
+                warehouseRefreshing = true
+                refreshScope.launch {
+                    runCatching {
+                        ShiguangWarehouseUpdater.refresh(this@EduSchoolSelectActivityHost)
+                    }.onSuccess { result ->
+                        if (result.changed) warehouseGeneration += 1
+                        if (manual) {
+                            Toast.makeText(
+                                this@EduSchoolSelectActivityHost,
+                                if (result.changed) "已更新适配列表" else "已是最新适配列表",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        } else if (result.changed) {
+                            Toast.makeText(
+                                this@EduSchoolSelectActivityHost,
+                                "适配列表已更新",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }.onFailure { error ->
+                        if (manual) {
+                            Toast.makeText(
+                                this@EduSchoolSelectActivityHost,
+                                "更新失败，继续使用当前适配列表：${error.message ?: "网络请求失败"}",
+                                Toast.LENGTH_LONG
+                            ).show()
+                        }
+                    }
+                    warehouseRefreshing = false
+                }
+            }
+            LaunchedEffect(Unit) {
+                if (ShiguangWarehouseUpdater.isRefreshStale(this@EduSchoolSelectActivityHost)) {
+                    refreshWarehouse(manual = false)
+                }
+            }
             CourseScheduleTheme(config = state.config) {
                 CrossActivityTransitionHost(
                     activity = this@EduSchoolSelectActivityHost,
@@ -6906,11 +6948,24 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                     DetailActivityScaffold(
                         title = "选择学校",
                         config = state.config,
-                        onBack = requestClose
+                        onBack = requestClose,
+                        topBarActions = { topBackdrop ->
+                            TopGlassIconButton(
+                                backdrop = topBackdrop,
+                                config = state.config,
+                                iconRes = R.drawable.ic_refresh,
+                                contentDescription = if (warehouseRefreshing) "正在更新适配器" else "更新适配器",
+                                onClick = { refreshWarehouse(manual = true) },
+                                modifier = Modifier
+                                    .size(42.dp)
+                                    .graphicsLayer { alpha = if (warehouseRefreshing) 0.46f else 1f }
+                            )
+                        }
                     ) { backdrop ->
                         EduSchoolPickerScreen(
                             state = state,
                             backdrop = backdrop,
+                            warehouseGeneration = warehouseGeneration,
                             onSelect = { adapter ->
                                 ActivityTransitionCoordinator.openImmediate(
                                     this@EduSchoolSelectActivityHost,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/identity/AppIconMode.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/identity/AppIconMode.kt
@@ -89,7 +89,6 @@ object AppIconManager {
             putBoolean(FollowsSystemDarkModeKey, followsSystemDarkMode)
             putBoolean(DarkThemeKey, darkTheme)
         }
-        applyStoredMode(context)
     }
 
     fun applyStoredMode(context: Context) {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixSettings.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixSettings.kt
@@ -361,6 +361,7 @@ internal fun GlassMiuixDetailActivityScaffold(
                                         color = Color.Transparent,
                                         scrollBehavior = scrollBehavior,
                                         navigationIconPadding = 16.dp,
+                                        actions = { topBarActions(contentBackdrop) },
                                         navigationIcon = {
                                             TopBackButton(
                                                 backdrop = contentBackdrop,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduImport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduImport.kt
@@ -1,6 +1,7 @@
 package com.xiaomanjun.sleepdownschedule.feature.importing
 
 import com.xiaomanjun.sleepdownschedule.*
+import com.xiaomanjun.sleepdownschedule.feature.importing.shiguang.ShiguangWarehouseUpdater
 
 import android.content.Context
 import android.os.Handler
@@ -8,11 +9,14 @@ import android.os.Looper
 import android.webkit.JavascriptInterface
 import android.widget.Toast
 import org.json.JSONArray
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.io.EOFException
+import java.io.IOException
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
@@ -137,24 +141,31 @@ object ShiguangWarehouse {
     private val quotedValue = Regex("""^\s*([A-Za-z_]+):\s*"?(.*?)"?\s*(?:#.*)?$""")
 
     fun loadAdapters(context: Context): List<EduAdapter> {
-        val warehouseAdapters = runCatching {
-            val pbAdapters = context.assets.open("$Root/school_index.pb").use { input ->
-                parseProtocolV2Index(input.readBytes())
-            }
-            // The official v2 protobuf index is synced from upstream and does not carry private
-            // SleepDown adaptations (e.g. 西南大学/武汉科技大学). Merge bundled YAML entries for
-            // schools missing from the protobuf so private forks keep their adapters.
-            val pbSchoolIds = pbAdapters.map { it.school.id }.toSet()
-            pbAdapters + loadLegacyYamlAdapters(context).filter { it.school.id !in pbSchoolIds }
-        }.getOrElse {
-            // Keep the source YAML path as a compatibility fallback for development snapshots and
-            // private warehouse forks that have not published the v2 protobuf artifact yet.
-            loadLegacyYamlAdapters(context)
-        }.map { adapter ->
+        val protocolAdapters = runCatching {
+            ShiguangWarehouseUpdater.cachedIndexFile(context)
+                .takeIf { it.isFile }
+                ?.readBytes()
+                ?.let(::parseProtocolV2Index)
+                ?.takeIf { it.isNotEmpty() }
+        }.getOrNull() ?: loadBundledAdapters(context)
+        // Preserve bundled private adaptations that are not published by the official index.
+        val protocolSchoolIds = protocolAdapters.map { it.school.id }.toSet()
+        val warehouseAdapters = (
+            protocolAdapters + loadLegacyYamlAdapters(context).filter { it.school.id !in protocolSchoolIds }
+            ).map { adapter ->
             if (adapter.isEduTestTool()) adapter.copy(importUrl = EDU_BRIDGE_TEST_PAGE_URL) else adapter
         }.filter { it.assetJsPath.isNotBlank() && (it.importUrl.isNotBlank() || it.isGeneralEduTool()) }
             .sortedWith(compareBy<EduAdapter> { it.school.initial }.thenBy { it.school.name }.thenBy { it.adapterName })
         return listOf(aiEduImportAdapter()) + warehouseAdapters
+    }
+
+    private fun loadBundledAdapters(context: Context): List<EduAdapter> = runCatching {
+        context.assets.open("$Root/school_index.pb").use { input ->
+            parseProtocolV2Index(input.readBytes())
+        }
+    }.getOrElse {
+        // YAML remains the bundled compatibility fallback for snapshots without a valid v2 index.
+        loadLegacyYamlAdapters(context)
     }
 
     private fun loadLegacyYamlAdapters(context: Context): List<EduAdapter> {
@@ -173,13 +184,30 @@ object ShiguangWarehouse {
         }
     }
 
-    fun loadScript(context: Context, adapter: EduAdapter): String {
-        val path = if (adapter.assetJsPath.contains("/")) {
-            "$Root/resources/${adapter.assetJsPath}"
-        } else {
-            "$Root/resources/${adapter.school.folder}/${adapter.assetJsPath}"
+    suspend fun resolveScript(context: Context, adapter: EduAdapter): String = withContext(Dispatchers.IO) {
+        val relativePath = ShiguangWarehouseUpdater.resourceRelativePath(adapter)
+        ShiguangWarehouseUpdater.cachedScriptFile(context, adapter)
+            .takeIf { it.isFile }
+            ?.readText()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return@withContext it }
+
+        var remoteFailure: Exception? = null
+        if (ShiguangWarehouseUpdater.hasValidRemoteIndex(context)) {
+            try {
+                return@withContext ShiguangWarehouseUpdater.resolveRemoteScript(context, adapter)
+            } catch (error: Exception) {
+                remoteFailure = error
+            }
         }
-        return context.assets.open(path).bufferedReader().readText()
+        try {
+            context.assets.open("$Root/resources/$relativePath").bufferedReader().use { it.readText() }
+        } catch (bundledFailure: Exception) {
+            throw IOException(
+                "无法获取拾光脚本 $relativePath：${remoteFailure?.message ?: bundledFailure.message}",
+                remoteFailure ?: bundledFailure
+            )
+        }
     }
 
     private fun parseSchools(text: String): List<EduSchool> {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -518,7 +518,7 @@ fun NormalizedAiManualImportScreen(
             error = "未找到拾光 WakeUp 解析器"
             return@LaunchedEffect
         }
-        val source = runCatching { ShiguangWarehouse.loadScript(context, adapter) }
+        val source = runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
             .getOrElse {
                 aiParsing = false
                 wakeUpImportInput = null
@@ -593,7 +593,7 @@ fun NormalizedAiManualImportScreen(
             error = "未找到拾光星链解析器"
             return@LaunchedEffect
         }
-        val source = runCatching { ShiguangWarehouse.loadScript(context, adapter) }
+        val source = runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
             .getOrElse {
                 aiParsing = false
                 starLinkImportInput = null
@@ -1362,10 +1362,11 @@ fun DonateSettingsScreen(
 fun EduSchoolPickerScreen(
     state: AppState,
     backdrop: Backdrop? = null,
+    warehouseGeneration: Int = 0,
     onSelect: (EduAdapter) -> Unit
 ) {
     val context = LocalContext.current
-    val adapters = remember {
+    val adapters = remember(warehouseGeneration) {
         runCatching { ShiguangWarehouse.loadAdapters(context) }
             .getOrDefault(emptyList())
             .filterNot { it.isWakeUpImportTool() || it.isStarLinkImportTool() }
@@ -3354,29 +3355,31 @@ fun EduImportBrowserScreen(
                 .getOrNull()
                 ?.let { onMessage("${it.message}；仍将尝试执行原有拾光导入脚本。") }
         }
-        runCatching { ShiguangWarehouse.loadScript(context, adapter) }
-            .onSuccess { script ->
-                importGeneration += 1
-                pendingImportGeneration = importGeneration
-                pendingOriginalImportScript = script
-                bridge.beginTask()
-                target.attachEduImportBridge(bridge)
-                // addJavascriptInterface becomes visible to page JavaScript only after a navigation.
-                // Reload the current page while the narrowly-scoped bridge is attached, run the
-                // adapter from onPageFinished, then detach on completion or timeout.
-                onMessage("已加载拾光仓库脚本，正在安全重载当前页面")
-                target.reload()
-                val generation = pendingImportGeneration
-                scope.launch {
-                    delay(15_000)
-                    if (importGeneration == generation && pendingOriginalImportScript != null) {
-                        pendingOriginalImportScript = null
-                        target.detachEduImportBridge()
-                        onMessage("当前页面重载超时，导入桥接已关闭，请检查网络后重试。")
+        scope.launch {
+            runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
+                .onSuccess { script ->
+                    importGeneration += 1
+                    pendingImportGeneration = importGeneration
+                    pendingOriginalImportScript = script
+                    bridge.beginTask()
+                    target.attachEduImportBridge(bridge)
+                    // addJavascriptInterface becomes visible to page JavaScript only after a navigation.
+                    // Reload the current page while the narrowly-scoped bridge is attached, run the
+                    // adapter from onPageFinished, then detach on completion or timeout.
+                    onMessage("已加载拾光仓库脚本，正在安全重载当前页面")
+                    target.reload()
+                    val generation = pendingImportGeneration
+                    launch {
+                        delay(15_000)
+                        if (importGeneration == generation && pendingOriginalImportScript != null) {
+                            pendingOriginalImportScript = null
+                            target.detachEduImportBridge()
+                            onMessage("当前页面重载超时，导入桥接已关闭，请检查网络后重试。")
+                        }
                     }
                 }
-            }
-            .onFailure { onMessage("拾光仓库脚本加载失败：${it.message ?: "找不到该学校的导入脚本"}") }
+                .onFailure { onMessage("拾光仓库脚本加载失败：${it.message ?: "找不到该学校的导入脚本"}") }
+        }
     }
 
     fun updateNavigationState(target: WebView?) {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWarehouseUpdater.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWarehouseUpdater.kt
@@ -1,0 +1,160 @@
+package com.xiaomanjun.sleepdownschedule.feature.importing.shiguang
+
+import android.content.Context
+import com.xiaomanjun.sleepdownschedule.feature.importing.EduAdapter
+import com.xiaomanjun.sleepdownschedule.feature.importing.ShiguangWarehouse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.net.HttpURLConnection
+import java.net.URL
+import java.net.URLEncoder
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+
+internal data class ShiguangRefreshResult(
+    val changed: Boolean,
+    val adapterCount: Int
+)
+
+internal object ShiguangWarehouseUpdater {
+    private const val CacheDirectoryName = "shiguang_warehouse"
+    private const val IndexFileName = "school_index.pb"
+    private const val PreferencesName = "shiguang_warehouse_metadata"
+    private const val LastSuccessfulRefreshKey = "last_successful_refresh"
+    private const val IndexShaKey = "index_sha256"
+    private const val IndexUrl =
+        "https://raw.githubusercontent.com/XingHeYuZhuan/shiguang_warehouse/index-pb-release/school_index.pb"
+    private const val ResourceBaseUrl =
+        "https://raw.githubusercontent.com/XingHeYuZhuan/shiguang_warehouse/main/resources/"
+    private val RefreshIntervalMillis = TimeUnit.DAYS.toMillis(7)
+    private val refreshMutex = Mutex()
+
+    fun cachedIndexFile(context: Context): File = File(cacheRoot(context), IndexFileName)
+
+    fun cachedScriptFile(context: Context, adapter: EduAdapter): File =
+        safeResourceFile(context, resourceRelativePath(adapter))
+
+    fun hasValidRemoteIndex(context: Context): Boolean = runCatching {
+        ShiguangWarehouse.parseProtocolV2Index(cachedIndexFile(context).readBytes()).isNotEmpty()
+    }.getOrDefault(false)
+
+    fun isRefreshStale(context: Context, nowMillis: Long = System.currentTimeMillis()): Boolean {
+        val lastSuccess = preferences(context).getLong(LastSuccessfulRefreshKey, 0L)
+        return lastSuccess <= 0L || nowMillis - lastSuccess >= RefreshIntervalMillis
+    }
+
+    suspend fun refresh(context: Context): ShiguangRefreshResult = withContext(Dispatchers.IO) {
+        refreshMutex.withLock {
+            val bytes = download(IndexUrl)
+            val adapters = ShiguangWarehouse.parseProtocolV2Index(bytes)
+            require(adapters.isNotEmpty()) { "远端拾光索引为空" }
+            val sha = bytes.sha256()
+            val previousSha = preferences(context).getString(IndexShaKey, null)
+            atomicWrite(cachedIndexFile(context), bytes)
+            val committed = preferences(context).edit()
+                .putLong(LastSuccessfulRefreshKey, System.currentTimeMillis())
+                .putString(IndexShaKey, sha)
+                .commit()
+            check(committed) { "无法保存拾光仓库刷新时间" }
+            ShiguangRefreshResult(
+                changed = previousSha != sha,
+                adapterCount = adapters.size
+            )
+        }
+    }
+
+    suspend fun resolveRemoteScript(context: Context, adapter: EduAdapter): String =
+        withContext(Dispatchers.IO) {
+            refreshMutex.withLock {
+                val relativePath = resourceRelativePath(adapter)
+                val target = safeResourceFile(context, relativePath)
+                target.takeIf { it.isFile }?.readText()?.takeIf { it.isNotBlank() }?.let { return@withLock it }
+
+                val encodedPath = relativePath.split('/').joinToString("/") { segment ->
+                    URLEncoder.encode(segment, Charsets.UTF_8.name()).replace("+", "%20")
+                }
+                val bytes = download(ResourceBaseUrl + encodedPath)
+                require(bytes.isNotEmpty()) { "远端拾光脚本为空：$relativePath" }
+                atomicWrite(target, bytes)
+                bytes.toString(Charsets.UTF_8)
+            }
+        }
+
+    internal fun resourceRelativePath(adapter: EduAdapter): String {
+        val path = if ('/' in adapter.assetJsPath) {
+            adapter.assetJsPath
+        } else {
+            "${adapter.school.folder}/${adapter.assetJsPath}"
+        }
+        require(path.isNotBlank()) { "拾光脚本路径为空" }
+        require('\\' !in path && !path.startsWith('/')) { "非法拾光脚本路径：$path" }
+        require(!Regex("^[A-Za-z][A-Za-z0-9+.-]*:").containsMatchIn(path)) {
+            "拾光脚本路径不能包含 scheme：$path"
+        }
+        val segments = path.split('/')
+        require(segments.none { it.isBlank() || it == "." || it == ".." }) { "非法拾光脚本路径：$path" }
+        require(path.endsWith(".js", ignoreCase = true)) { "拾光资源不是 JS：$path" }
+        return segments.joinToString("/")
+    }
+
+    private fun cacheRoot(context: Context): File =
+        File(context.filesDir, CacheDirectoryName).apply { mkdirs() }
+
+    private fun safeResourceFile(context: Context, relativePath: String): File {
+        val resources = File(cacheRoot(context), "resources").apply { mkdirs() }
+        val target = File(resources, relativePath)
+        val rootPath = resources.canonicalFile.toPath()
+        val targetPath = target.canonicalFile.toPath()
+        require(targetPath.startsWith(rootPath)) { "拾光脚本路径越界：$relativePath" }
+        return target
+    }
+
+    private fun preferences(context: Context) =
+        context.applicationContext.getSharedPreferences(PreferencesName, Context.MODE_PRIVATE)
+
+    private fun download(url: String): ByteArray {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        return try {
+            connection.connectTimeout = 12_000
+            connection.readTimeout = 20_000
+            connection.instanceFollowRedirects = false
+            connection.setRequestProperty("Accept", "application/octet-stream, text/javascript, */*")
+            connection.setRequestProperty("User-Agent", "SleepDown-Schedule/ShiguangWarehouse")
+            val status = connection.responseCode
+            if (status !in 200..299) throw IOException("拾光仓库请求失败：HTTP $status")
+            connection.inputStream.use { it.readBytes() }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun atomicWrite(target: File, bytes: ByteArray) {
+        target.parentFile?.mkdirs()
+        val temporary = File(target.parentFile, ".${target.name}.tmp")
+        try {
+            FileOutputStream(temporary).use { output ->
+                output.write(bytes)
+                output.fd.sync()
+            }
+            Files.move(
+                temporary.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING
+            )
+        } finally {
+            temporary.delete()
+        }
+    }
+
+    private fun ByteArray.sha256(): String = MessageDigest.getInstance("SHA-256")
+        .digest(this)
+        .joinToString("") { byte -> "%02x".format(byte) }
+}


### PR DESCRIPTION
## 完成

- 手动深浅色切换时只记录期望的 launcher appearance，不再在 `CourseScheduleTheme` 重组或 MainActivity 返回交接阶段修改 launcher alias
- 应用进入后台后只在目标 alias 确实变化时同步图标；浅色、深色、跟随系统三个 alias 均保留
- 增加官方拾光远端索引更新：`index-pb-release/school_index.pb`
- 远端索引经 protocol v2 解析且非空后才原子写入 `filesDir/shiguang_warehouse/`
- `loadAdapters()` 优先有效远端缓存，失败回 APK 内置 protobuf，再保留既有 YAML compatibility 数据
- 拾光 JS 改为异步解析：脚本缓存 → 官方 `main/resources/` 按需下载 → APK 内置脚本
- WakeUp、星链与常规教务导入全部迁移到同一脚本解析链路，JS bridge 仍只在执行导入期间临时挂载
- “选择学校”右上增加已有液态玻璃样式刷新按钮；成功后当前列表立即重载
- 进入选择学校页时仅当上次成功刷新已满 7 天才后台检查；失败不更新时间且不影响当前列表
- SleepDown 内置 AI 教务入口保持在列表首位

## Stack

Base：`codex/edu-browser-ui-webview`（PR #19）

## Crash 证据

当前没有连接 Android 设备，工作区也没有该复现路径的 FATAL stack，因此无法提供真实 exception 与第一条 SleepDown stack frame，也没有伪造结论。修复依据用户确认的图标刷新方向、实际调用时序和项目已有 Oplus 历史注释；仍需设备实机覆盖浅色、深色与跟随系统返回首页路径。

## 验证

- `compileGithubReleaseKotlin`：通过
- `assembleGithubRelease`：通过（R8、资源压缩、lintVital、签名校验均执行）
- 当前无 ADB 设备，因此未安装、未启动、未实机复现
- 远端来源已核对为官方 `XingHeYuZhuan/shiguang_warehouse` 的 `index-pb-release` 与 `main/resources`

## 范围

未修改 PR #19 Browser Dock/WebView capability，也未修改 AI Import 后台、通知、Day Agent、Widget、数据库、后端。