### PR TITLE
统一课程调色入口并完善教务浏览器玻璃交互

### DIFF
--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -4368,6 +4368,7 @@ fun DetailActivityScaffold(
     centerCompactTitle: Boolean = false,
     compactTitleMatchesSettings: Boolean = false,
     topBarVisible: Boolean = true,
+    topBarBackdropOverride: Backdrop? = null,
     topBarActions: @Composable (Backdrop?) -> Unit = {},
     content: @Composable (Backdrop?) -> Unit
 ) {
@@ -4381,6 +4382,7 @@ fun DetailActivityScaffold(
         centerCompactTitle = centerCompactTitle,
         compactTitleMatchesSettings = compactTitleMatchesSettings,
         topBarVisible = topBarVisible,
+        topBarBackdropOverride = topBarBackdropOverride,
         topBarActions = topBarActions,
         content = content
     )
@@ -6956,6 +6958,10 @@ open class EduImportActivityHost : ComponentActivity() {
             val state by viewModel.state.collectAsStateWithLifecycle()
             val adapter = remember { eduAdapterFromIntentKey(intent.getStringExtra(EduAdapterExtra)) }
             var pendingDraft by remember { mutableStateOf<ImportDraft?>(null) }
+            val eduWebContentBackdrop = rememberGlassLayerBackdrop(
+                domain = GlassBackdropDomain.Content,
+                providerId = "edu-import-web-content"
+            )
             CourseScheduleTheme(config = state.config) {
                 if (pendingDraft == null) {
                     DetailActivityScaffold(
@@ -6963,7 +6969,8 @@ open class EduImportActivityHost : ComponentActivity() {
                         config = state.config,
                         onBack = { finish() },
                         isolateContentFromBackdrop = true,
-                        compactTopBar = true
+                        compactTopBar = true,
+                        topBarBackdropOverride = eduWebContentBackdrop
                     ) { backdrop ->
                         if (adapter == null) {
                             Box(
@@ -6978,6 +6985,7 @@ open class EduImportActivityHost : ComponentActivity() {
                                 state = state,
                                 adapter = adapter,
                                 backdrop = backdrop,
+                                webContentBackdrop = eduWebContentBackdrop,
                                 useDetailTopPadding = true,
                                 onParsed = { draft -> pendingDraft = draft }
                             )

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -6919,8 +6919,9 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                                 contentDescription = if (warehouseRefreshing) "正在更新适配器" else "更新适配器",
                                 onClick = { refreshWarehouse(manual = true) },
                                 modifier = Modifier
-                                    .size(42.dp)
-                                    .graphicsLayer { alpha = if (warehouseRefreshing) 0.46f else 1f }
+                                    .size(SleepDownDesignTokens.SecondaryPage.BackButtonSize)
+                                    .graphicsLayer { alpha = if (warehouseRefreshing) 0.46f else 1f },
+                                buttonHeight = SleepDownDesignTokens.SecondaryPage.BackButtonSize
                             )
                         }
                     ) { backdrop ->
@@ -6970,6 +6971,8 @@ open class EduImportActivityHost : ComponentActivity() {
                         onBack = { finish() },
                         isolateContentFromBackdrop = true,
                         compactTopBar = true,
+                        centerCompactTitle = true,
+                        compactTitleMatchesSettings = true,
                         topBarBackdropOverride = eduWebContentBackdrop
                     ) { backdrop ->
                         if (adapter == null) {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -91,7 +91,6 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Colorize
-import androidx.compose.material.icons.filled.Palette
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
@@ -5582,55 +5581,6 @@ private fun CourseColorModeRow(
         }
     }
 
-    @Composable
-    fun PaletteButton() {
-        val buttonColor = if (customSelected) {
-            MaterialTheme.colorScheme.primary
-        } else {
-            ComposeColor.White.copy(alpha = 0.90f)
-        }
-        val iconColor = if (customSelected) ComposeColor.White else ComposeColor(0xFF1A1A1A)
-        if (backdrop != null) {
-            LiquidButton(
-                onClick = onOpenPalette,
-                backdrop = backdrop,
-                modifier = Modifier.size(32.dp),
-                height = 32.dp,
-                contentPadding = PaddingValues(0.dp),
-                surfaceColor = buttonColor,
-                blurRadius = 8.dp,
-                lensHeight = 18.dp,
-                lensAmount = 22.dp,
-                chromaticAberration = false
-            ) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.Filled.Palette,
-                        contentDescription = "自定义课程卡颜色",
-                        tint = iconColor,
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
-            }
-        } else {
-            Surface(
-                modifier = Modifier.size(32.dp),
-                shape = RoundedCornerShape(50),
-                color = buttonColor,
-                onClick = onOpenPalette
-            ) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = Icons.Filled.Palette,
-                        contentDescription = "自定义课程卡颜色",
-                        tint = iconColor,
-                        modifier = Modifier.size(18.dp)
-                    )
-                }
-            }
-        }
-    }
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -5654,8 +5604,13 @@ private fun CourseColorModeRow(
                 repeat(5) { index ->
                     Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
                         when (index) {
-                            1 -> PresetButton(presets.first())
-                            3 -> PaletteButton()
+                            0 -> PresetButton(presets.first())
+                            4 -> CourseColorPaletteButton(
+                                backdrop = backdrop,
+                                selected = customSelected,
+                                onClick = onOpenPalette,
+                                size = 32.dp
+                            )
                         }
                     }
                 }
@@ -5666,7 +5621,12 @@ private fun CourseColorModeRow(
                     }
                 }
                 Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
-                    PaletteButton()
+                    CourseColorPaletteButton(
+                        backdrop = backdrop,
+                        selected = customSelected,
+                        onClick = onOpenPalette,
+                        size = 32.dp
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -6918,9 +6918,7 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                                 iconRes = R.drawable.ic_refresh,
                                 contentDescription = if (warehouseRefreshing) "正在更新适配器" else "更新适配器",
                                 onClick = { refreshWarehouse(manual = true) },
-                                modifier = Modifier
-                                    .size(SleepDownDesignTokens.SecondaryPage.BackButtonSize)
-                                    .graphicsLayer { alpha = if (warehouseRefreshing) 0.46f else 1f },
+                                modifier = Modifier.size(SleepDownDesignTokens.SecondaryPage.BackButtonSize),
                                 buttonHeight = SleepDownDesignTokens.SecondaryPage.BackButtonSize
                             )
                         }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixPopup.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixPopup.kt
@@ -18,13 +18,16 @@ import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.LocalCenteredDialog
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -50,6 +53,7 @@ import top.yukonga.miuix.kmp.preference.OverlayDropdownPreference
 internal data class SleepDownLiquidMenuItem(
     val key: String,
     val text: String,
+    val iconRes: Int? = null,
     val summary: String? = null,
     val selected: Boolean = false,
     val enabled: Boolean = true,
@@ -248,13 +252,23 @@ internal fun SleepDownLiquidDropdownPreference(
     )
 }
 
-private fun SleepDownLiquidMenuItem.asMiuixDropdownItem(): DropdownItem = DropdownItem(
+private fun SleepDownLiquidMenuItem.asMiuixDropdownItem(iconColor: Color): DropdownItem = DropdownItem(
     text = text,
     enabled = enabled,
     selected = selected || accent,
     onClick = onClick,
+    icon = iconRes?.let { resourceId ->
+        { modifier ->
+            Icon(
+                painter = painterResource(resourceId),
+                contentDescription = null,
+                tint = iconColor,
+                modifier = modifier.size(20.dp)
+            )
+        }
+    },
     summary = summary,
-    children = children.takeIf { it.isNotEmpty() }?.map { it.asMiuixDropdownItem() }
+    children = children.takeIf { it.isNotEmpty() }?.map { it.asMiuixDropdownItem(iconColor) }
 )
 
 @Composable
@@ -281,7 +295,10 @@ internal fun SleepDownLiquidCascadingPopup(
     } else {
         primaryPopupBackdrop
     }
-    val entry = remember(items) { DropdownEntry(items.map { it.asMiuixDropdownItem() }) }
+    val popupContentColor = contentColor ?: sleepDownPanelForegroundColor(config)
+    val entry = remember(items, popupContentColor) {
+        DropdownEntry(items.map { it.asMiuixDropdownItem(popupContentColor) })
+    }
     val basePrimaryVisualStyle = rememberMiuixListPopupStyle(
         backdrop = completeUnderlayBackdrop,
         config = config,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixSettings.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/core/ui/settings/GlassMiuixSettings.kt
@@ -280,6 +280,7 @@ internal fun GlassMiuixDetailActivityScaffold(
     centerCompactTitle: Boolean,
     compactTitleMatchesSettings: Boolean,
     topBarVisible: Boolean,
+    topBarBackdropOverride: Backdrop?,
     topBarActions: @Composable (Backdrop?) -> Unit,
     content: @Composable (Backdrop?) -> Unit
 ) {
@@ -296,6 +297,7 @@ internal fun GlassMiuixDetailActivityScaffold(
         drawRect(pageColor)
         drawContent()
     }
+    val topBarBackdrop = topBarBackdropOverride ?: contentBackdrop
     val scrollBehavior = rememberSettingsScrollBehavior()
     val compactTopBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() +
         SleepDownDesignTokens.SecondaryPage.CompactTopBarHeight
@@ -341,18 +343,18 @@ internal fun GlassMiuixDetailActivityScaffold(
                         if (topBarVisible) {
                             SettingsGradientTopBar(
                                 config = pageConfig,
-                                backdrop = contentBackdrop,
+                                backdrop = topBarBackdrop,
                                 enabled = showTopGradientBlur
                             ) {
                                 if (compactTopBar) {
                                     DetailTopBar(
                                         title = title,
                                         config = pageConfig,
-                                        backdrop = contentBackdrop,
+                                        backdrop = topBarBackdrop,
                                         onBack = onBack,
                                         centerTitle = centerCompactTitle,
                                         useMiuixCollapsedTitleStyle = compactTitleMatchesSettings,
-                                        actions = { topBarActions(contentBackdrop) }
+                                        actions = { topBarActions(topBarBackdrop) }
                                     )
                                 } else {
                                     TopAppBar(
@@ -361,10 +363,10 @@ internal fun GlassMiuixDetailActivityScaffold(
                                         color = Color.Transparent,
                                         scrollBehavior = scrollBehavior,
                                         navigationIconPadding = 16.dp,
-                                        actions = { topBarActions(contentBackdrop) },
+                                        actions = { topBarActions(topBarBackdrop) },
                                         navigationIcon = {
                                             TopBackButton(
-                                                backdrop = contentBackdrop,
+                                                backdrop = topBarBackdrop,
                                                 config = pageConfig,
                                                 onClick = onBack,
                                                 modifier = Modifier.size(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseColorPicker.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseColorPicker.kt
@@ -2,29 +2,38 @@ package com.xiaomanjun.sleepdownschedule.feature.course.editor
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Palette
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import com.kyant.backdrop.Backdrop
+import com.kyant.backdrop.catalog.components.LiquidButton
 import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
 import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.QuickSheetLiquidAction
 import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.SleepDownDesignTokens
@@ -37,6 +46,7 @@ import com.xiaomanjun.sleepdownschedule.glass.ui.appUsesDarkTheme
 internal fun CourseColorPicker(
     show: Boolean,
     selectedColorArgb: Long?,
+    automaticColorArgb: Long,
     backdrop: Backdrop?,
     config: ScheduleConfigEntity,
     renderInRootScaffold: Boolean,
@@ -46,6 +56,7 @@ internal fun CourseColorPicker(
 ) {
     val palette = LocalCourseCardPalette.current.ifEmpty { DefaultCourseCardPalette }
     var pendingColor by remember(show, selectedColorArgb) { mutableStateOf(selectedColorArgb) }
+    var paletteAnchorVersion by remember(show, selectedColorArgb, automaticColorArgb) { mutableIntStateOf(0) }
     val foreground = if (appUsesDarkTheme(config)) Color.White else Color(0xFF111111)
     SleepDownPickerDialog(
         show = show,
@@ -69,7 +80,10 @@ internal fun CourseColorPicker(
                     primary = pendingColor == null,
                     modifier = Modifier.fillMaxWidth(),
                     height = 42.dp,
-                    onClick = { pendingColor = null }
+                    onClick = {
+                        pendingColor = null
+                        paletteAnchorVersion += 1
+                    }
                 )
                 Text(
                     text = "当前课程色板",
@@ -91,23 +105,28 @@ internal fun CourseColorPicker(
                                 if (selected) MaterialTheme.colorScheme.primary
                                 else foreground.copy(alpha = 0.28f)
                             ),
-                            onClick = { pendingColor = colorArgb }
+                            onClick = {
+                                pendingColor = colorArgb
+                                paletteAnchorVersion += 1
+                            }
                         ) {}
                     }
                 }
-                top.yukonga.miuix.kmp.basic.ColorPalette(
-                    color = Color((pendingColor ?: palette.first()).toInt()),
-                    onColorChanged = { color ->
-                        pendingColor = color.copy(alpha = 1f).toArgb().toLong() and 0xFFFFFFFFL
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    rows = 7,
-                    hueColumns = 12,
-                    includeGrayColumn = true,
-                    showPreview = true,
-                    cornerRadius = 16.dp,
-                    indicatorRadius = 10.dp
-                )
+                key(paletteAnchorVersion) {
+                    top.yukonga.miuix.kmp.basic.ColorPalette(
+                        color = Color((pendingColor ?: automaticColorArgb).toInt()),
+                        onColorChanged = { color ->
+                            pendingColor = color.copy(alpha = 1f).toArgb().toLong() and 0xFFFFFFFFL
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        rows = 7,
+                        hueColumns = 12,
+                        includeGrayColumn = true,
+                        showPreview = true,
+                        cornerRadius = 16.dp,
+                        indicatorRadius = 10.dp
+                    )
+                }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(SleepDownDesignTokens.Dialog.ActionSpacing)
@@ -135,6 +154,57 @@ internal fun CourseColorPicker(
                         }
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun CourseColorPaletteButton(
+    backdrop: Backdrop?,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    size: androidx.compose.ui.unit.Dp = 34.dp
+) {
+    val surfaceColor = if (selected) MaterialTheme.colorScheme.primary else Color.White.copy(alpha = 0.90f)
+    val iconColor = if (selected) Color.White else Color(0xFF1A1A1A)
+    if (backdrop != null) {
+        LiquidButton(
+            onClick = onClick,
+            backdrop = backdrop,
+            modifier = modifier.size(size),
+            height = size,
+            contentPadding = PaddingValues(0.dp),
+            surfaceColor = surfaceColor,
+            blurRadius = 8.dp,
+            lensHeight = 18.dp,
+            lensAmount = 22.dp,
+            chromaticAberration = false
+        ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Filled.Palette,
+                    contentDescription = "打开调色盘",
+                    tint = iconColor,
+                    modifier = Modifier.size(size * 0.56f)
+                )
+            }
+        }
+    } else {
+        Surface(
+            modifier = modifier.size(size),
+            shape = RoundedCornerShape(50),
+            color = surfaceColor,
+            onClick = onClick
+        ) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Icon(
+                    imageVector = Icons.Filled.Palette,
+                    contentDescription = "打开调色盘",
+                    tint = iconColor,
+                    modifier = Modifier.size(size * 0.56f)
+                )
             }
         }
     }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseEditorUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/editor/CourseEditorUi.kt
@@ -824,6 +824,10 @@ fun NormalizedCourseEditorScreen(
             CourseColorPicker(
                 show = colorPickerVisible,
                 selectedColorArgb = drafts.getValue(page).customColorArgb,
+                automaticColorArgb = courseCardBaseColor(
+                    config,
+                    editorGroups[page].representative?.copy(customColorArgb = null)
+                ).toArgb().toLong() and 0xFFFFFFFFL,
                 backdrop = backdrop,
                 config = config,
                 renderInRootScaffold = pickerRenderInRootScaffold,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/management/CourseManagementUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/course/management/CourseManagementUi.kt
@@ -46,7 +46,6 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -72,8 +71,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AutoAwesome
-import androidx.compose.material.icons.filled.Palette
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -99,6 +96,7 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInWindow
@@ -680,6 +678,7 @@ internal fun CourseManagementDetailPage(
                     selectedColor = selectedColor,
                     onColorSelected = { selectedColor = it },
                     onOpenColorPicker = { colorPickerVisible = true },
+                    backdrop = cardBackdrop,
                     config = state.config
                 )
             }
@@ -749,6 +748,10 @@ internal fun CourseManagementDetailPage(
         CourseColorPicker(
             show = colorPickerVisible,
             selectedColorArgb = selectedColor,
+            automaticColorArgb = courseCardBaseColor(
+                state.config,
+                group.representative.copy(customColorArgb = null)
+            ).toArgb().toLong() and 0xFFFFFFFFL,
             backdrop = pickerBackdrop,
             config = state.config,
             renderInRootScaffold = true,
@@ -873,6 +876,7 @@ private fun CourseIdentityCard(
     selectedColor: Long?,
     onColorSelected: (Long?) -> Unit,
     onOpenColorPicker: () -> Unit,
+    backdrop: Backdrop?,
     config: ScheduleConfigEntity
 ) {
     CourseManagementSettingsSection(title = "课程信息") {
@@ -890,40 +894,13 @@ private fun CourseIdentityCard(
                 insideMargin = PaddingValues(horizontal = 14.dp, vertical = 8.dp)
             )
             val palette = LocalCourseCardPalette.current.ifEmpty { DefaultCourseCardPalette }
-            FlowRow(
+            val visiblePalette = palette.take(4)
+            Row(
                 modifier = Modifier.fillMaxWidth().padding(start = 14.dp, end = 14.dp, bottom = 10.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Box(
-                    Modifier.size(34.dp).clip(RoundedCornerShape(50))
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .then(
-                            if (selectedColor == null) {
-                                Modifier.border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(50))
-                            } else {
-                                Modifier
-                            }
-                        )
-                        .clickable { onColorSelected(null) },
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (selectedColor == null) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_check),
-                            contentDescription = "已选择自动课程颜色",
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.align(Alignment.TopEnd).padding(2.dp).size(11.dp)
-                        )
-                    }
-                    Icon(
-                        imageVector = Icons.Filled.AutoAwesome,
-                        contentDescription = "自动课程颜色",
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(19.dp)
-                    )
-                }
-                palette.take(6).forEach { argb ->
+                visiblePalette.forEach { argb ->
                     val selected = selectedColor == argb
                     Box(
                         Modifier
@@ -957,31 +934,12 @@ private fun CourseIdentityCard(
                         }
                     }
                 }
-                val customSelected = selectedColor != null && selectedColor !in palette.take(6)
-                Box(
-                    Modifier.size(34.dp).clip(RoundedCornerShape(50))
-                        .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .then(
-                            if (customSelected) {
-                                Modifier.border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(50))
-                            } else {
-                                Modifier
-                            }
-                        )
-                        .clickable(onClick = onOpenColorPicker),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Filled.Palette,
-                        contentDescription = "打开调色盘",
-                        tint = if (customSelected) {
-                            MaterialTheme.colorScheme.primary
-                        } else {
-                            MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                        modifier = Modifier.size(19.dp)
-                    )
-                }
+                CourseColorPaletteButton(
+                    backdrop = backdrop,
+                    selected = selectedColor != null && selectedColor !in visiblePalette,
+                    onClick = onOpenColorPicker,
+                    size = 34.dp
+                )
             }
         }
     }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduBrowserDock.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduBrowserDock.kt
@@ -62,7 +62,7 @@ import com.xiaomanjun.sleepdownschedule.glass.ui.platformMotionBlurRenderEffect
 import com.xiaomanjun.sleepdownschedule.model.ScheduleConfigEntity
 import com.xiaomanjun.sleepdownschedule.transition.legacy.detailMotionBlurRadiusDp
 
-private val BrowserDockImeEasing = CubicBezierEasing(0.18f, 0f, 0f, 1f)
+private val BrowserDockImeEasing = CubicBezierEasing(0.42f, 0f, 0.58f, 1f)
 private val BrowserDockLeftControlsWidth = 93.dp
 private val BrowserDockRightControlsWidth = 82.dp
 

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduBrowserDock.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduBrowserDock.kt
@@ -5,11 +5,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imeAnimationSource
+import androidx.compose.foundation.layout.imeAnimationTarget
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -27,6 +33,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
@@ -35,14 +42,15 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.animation.core.CubicBezierEasing
 import com.kyant.backdrop.Backdrop
 import com.kyant.backdrop.catalog.components.LiquidButton
 import com.xiaomanjun.sleepdownschedule.R
@@ -50,8 +58,15 @@ import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.sleepDownPanelForeg
 import com.xiaomanjun.sleepdownschedule.core.ui.settings.SleepDownLiquidCascadingPopup
 import com.xiaomanjun.sleepdownschedule.core.ui.settings.SleepDownLiquidMenuItem
 import com.xiaomanjun.sleepdownschedule.glass.ui.appUsesDarkTheme
+import com.xiaomanjun.sleepdownschedule.glass.ui.platformMotionBlurRenderEffect
 import com.xiaomanjun.sleepdownschedule.model.ScheduleConfigEntity
+import com.xiaomanjun.sleepdownschedule.transition.legacy.detailMotionBlurRadiusDp
 
+private val BrowserDockImeEasing = CubicBezierEasing(0.18f, 0f, 0f, 1f)
+private val BrowserDockLeftControlsWidth = 93.dp
+private val BrowserDockRightControlsWidth = 82.dp
+
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun EduBrowserDock(
     config: ScheduleConfigEntity,
@@ -73,6 +88,7 @@ internal fun EduBrowserDock(
     modifier: Modifier = Modifier
 ) {
     val foreground = sleepDownPanelForegroundColor(config)
+    val density = LocalDensity.current
     val focusManager = LocalFocusManager.current
     val keyboard = LocalSoftwareKeyboardController.current
     var addressFocused by remember { mutableStateOf(false) }
@@ -86,6 +102,22 @@ internal fun EduBrowserDock(
     } else {
         Color(0xFF16181D).copy(alpha = 0.78f)
     }
+    val navigationBottom = WindowInsets.navigationBars.getBottom(density)
+    val imeBottom = WindowInsets.ime.getBottom(density)
+    val imeSourceBottom = WindowInsets.imeAnimationSource.getBottom(density)
+    val imeTargetBottom = WindowInsets.imeAnimationTarget.getBottom(density)
+    val imeTravel = (maxOf(imeBottom, imeSourceBottom, imeTargetBottom) - navigationBottom)
+        .coerceAtLeast(0)
+    val rawImeProgress = if (imeTravel == 0) {
+        0f
+    } else {
+        ((imeBottom - navigationBottom).coerceAtLeast(0).toFloat() / imeTravel).coerceIn(0f, 1f)
+    }
+    val addressExpansionProgress = BrowserDockImeEasing.transform(rawImeProgress)
+    val sideControlsAlpha = (1f - addressExpansionProgress).coerceIn(0f, 1f)
+    val sideControlsBlurPx = detailMotionBlurRadiusDp(addressExpansionProgress) * density.density
+    val sideControlsEnabled = addressExpansionProgress < 0.02f
+    val sideControlsTravelPx = with(density) { 18.dp.toPx() } * addressExpansionProgress
 
     Box(modifier = modifier) {
         LiquidButton(
@@ -103,6 +135,8 @@ internal fun EduBrowserDock(
             surfaceColor = dockSurfaceColor,
             shadowEnabled = lightDockGlass,
             highlightEnabled = true,
+            isInteractive = true,
+            highlightRadiusMultiplier = 2.2f,
             clipToBounds = false,
             clickTargetEnabled = false,
             pressExpansion = 1.5.dp
@@ -114,35 +148,66 @@ internal fun EduBrowserDock(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(2.dp)
             ) {
-                EduBrowserDockIcon(
-                    iconRes = R.drawable.ic_arrow_back,
-                    contentDescription = "网页后退",
-                    foreground = foreground,
-                    enabled = canGoBack,
-                    onClick = onBack
-                )
-                EduBrowserDockIcon(
-                    iconRes = R.drawable.ic_arrow_back,
-                    contentDescription = "网页前进",
-                    foreground = foreground,
-                    enabled = canGoForward,
-                    flipHorizontal = true,
-                    onClick = onForward
-                )
                 Box(
-                    Modifier
-                        .padding(horizontal = 4.dp)
-                        .width(1.dp)
-                        .height(24.dp)
-                        .background(foreground.copy(alpha = 0.16f))
-                )
+                    modifier = Modifier
+                        .width(BrowserDockLeftControlsWidth * sideControlsAlpha)
+                        .height(40.dp)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .width(BrowserDockLeftControlsWidth)
+                            .height(40.dp)
+                            .graphicsLayer {
+                                translationX = -sideControlsTravelPx
+                                alpha = sideControlsAlpha
+                                compositingStrategy = if (sideControlsBlurPx > 0.01f) {
+                                    CompositingStrategy.Offscreen
+                                } else {
+                                    CompositingStrategy.Auto
+                                }
+                                renderEffect = platformMotionBlurRenderEffect(sideControlsBlurPx)
+                                clip = false
+                            },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        EduBrowserDockIcon(
+                            iconRes = R.drawable.ic_arrow_back,
+                            contentDescription = "网页后退",
+                            foreground = foreground,
+                            enabled = canGoBack && sideControlsEnabled,
+                            onClick = onBack
+                        )
+                        EduBrowserDockIcon(
+                            iconRes = R.drawable.ic_arrow_back,
+                            contentDescription = "网页前进",
+                            foreground = foreground,
+                            enabled = canGoForward && sideControlsEnabled,
+                            flipHorizontal = true,
+                            onClick = onForward
+                        )
+                        Box(
+                            Modifier
+                                .padding(horizontal = 4.dp)
+                                .width(1.dp)
+                                .height(24.dp)
+                                .background(foreground.copy(alpha = 0.16f))
+                        )
+                    }
+                }
                 BasicTextField(
                     value = address,
                     onValueChange = onAddressChange,
                     modifier = Modifier
                         .weight(1f)
                         .height(40.dp)
-                        .onFocusChanged { addressFocused = it.isFocused },
+                        .onFocusChanged {
+                            addressFocused = it.isFocused
+                            if (it.isFocused) {
+                                importMenuVisible = false
+                                moreMenuVisible = false
+                            }
+                        },
                     singleLine = true,
                     textStyle = MaterialTheme.typography.bodyMedium.copy(
                         color = if (addressFocused) foreground else Color.Transparent
@@ -187,38 +252,51 @@ internal fun EduBrowserDock(
                 )
                 Box(
                     modifier = Modifier
+                        .width(BrowserDockRightControlsWidth * sideControlsAlpha)
                         .height(40.dp)
-                        .onGloballyPositioned { importAnchor = it.boundsInRoot() }
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .width(BrowserDockRightControlsWidth)
+                            .height(40.dp)
+                            .graphicsLayer {
+                                translationX = sideControlsTravelPx
+                                alpha = sideControlsAlpha
+                                compositingStrategy = if (sideControlsBlurPx > 0.01f) {
+                                    CompositingStrategy.Offscreen
+                                } else {
+                                    CompositingStrategy.Auto
+                                }
+                                renderEffect = platformMotionBlurRenderEffect(sideControlsBlurPx)
+                                clip = false
+                            },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(2.dp)
+                    ) {
+                        EduBrowserDockIcon(
+                            iconRes = R.drawable.ic_school_import,
+                            contentDescription = "导入",
+                            foreground = foreground,
+                            enabled = sideControlsEnabled,
+                            modifier = Modifier.onGloballyPositioned { importAnchor = it.boundsInRoot() },
                             onClick = {
                                 moreMenuVisible = false
                                 importMenuVisible = !importMenuVisible
                             }
                         )
-                        .padding(horizontal = 8.dp),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        "导入",
-                        color = if (aiImportRunning) foreground.copy(alpha = 0.55f) else foreground,
-                        style = MaterialTheme.typography.labelMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1
-                    )
-                }
-                EduBrowserDockIcon(
-                    iconRes = R.drawable.ic_more_horizontal,
-                    contentDescription = "更多浏览器操作",
-                    foreground = foreground,
-                    enabled = true,
-                    modifier = Modifier.onGloballyPositioned { moreAnchor = it.boundsInRoot() },
-                    onClick = {
-                        importMenuVisible = false
-                        moreMenuVisible = !moreMenuVisible
+                        EduBrowserDockIcon(
+                            iconRes = R.drawable.ic_more_horizontal,
+                            contentDescription = "更多浏览器操作",
+                            foreground = foreground,
+                            enabled = sideControlsEnabled,
+                            modifier = Modifier.onGloballyPositioned { moreAnchor = it.boundsInRoot() },
+                            onClick = {
+                                importMenuVisible = false
+                                moreMenuVisible = !moreMenuVisible
+                            }
+                        )
                     }
-                )
+                }
             }
         }
 
@@ -230,6 +308,7 @@ internal fun EduBrowserDock(
                     add(SleepDownLiquidMenuItem(
                         key = "edu-original-import",
                         text = "常规教务导入",
+                        iconRes = R.drawable.ic_school_import,
                         onClick = {
                             importMenuVisible = false
                             onOriginalImport()
@@ -239,6 +318,7 @@ internal fun EduBrowserDock(
                 add(SleepDownLiquidMenuItem(
                     key = "edu-ai-import",
                     text = "AI 导入",
+                    iconRes = R.drawable.ic_ai_import,
                     enabled = !aiImportRunning,
                     onClick = {
                         importMenuVisible = false
@@ -258,6 +338,7 @@ internal fun EduBrowserDock(
                 SleepDownLiquidMenuItem(
                     key = "edu-refresh",
                     text = "刷新",
+                    iconRes = R.drawable.ic_refresh,
                     onClick = {
                         moreMenuVisible = false
                         onRefresh()
@@ -266,6 +347,7 @@ internal fun EduBrowserDock(
                 SleepDownLiquidMenuItem(
                     key = "edu-web-mode",
                     text = if (desktopMode) "切换为手机网页" else "切换为电脑网页",
+                    iconRes = R.drawable.ic_web_mode,
                     onClick = {
                         moreMenuVisible = false
                         onToggleDesktopMode()

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduBrowserDock.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduBrowserDock.kt
@@ -49,6 +49,7 @@ import com.xiaomanjun.sleepdownschedule.R
 import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.sleepDownPanelForegroundColor
 import com.xiaomanjun.sleepdownschedule.core.ui.settings.SleepDownLiquidCascadingPopup
 import com.xiaomanjun.sleepdownschedule.core.ui.settings.SleepDownLiquidMenuItem
+import com.xiaomanjun.sleepdownschedule.glass.ui.appUsesDarkTheme
 import com.xiaomanjun.sleepdownschedule.model.ScheduleConfigEntity
 
 @Composable
@@ -79,6 +80,12 @@ internal fun EduBrowserDock(
     var moreMenuVisible by remember { mutableStateOf(false) }
     var importAnchor by remember { mutableStateOf(Rect.Zero) }
     var moreAnchor by remember { mutableStateOf(Rect.Zero) }
+    val lightDockGlass = !appUsesDarkTheme(config)
+    val dockSurfaceColor = if (lightDockGlass) {
+        Color.White.copy(alpha = 0.22f)
+    } else {
+        Color(0xFF16181D).copy(alpha = 0.78f)
+    }
 
     Box(modifier = modifier) {
         LiquidButton(
@@ -89,12 +96,14 @@ internal fun EduBrowserDock(
                 .height(56.dp),
             height = 56.dp,
             contentPadding = PaddingValues(0.dp),
-            blurRadius = 16.dp,
-            lensHeight = 18.dp,
-            lensAmount = 28.dp,
+            blurRadius = 5.dp,
+            lensHeight = 14.dp,
+            lensAmount = 24.dp,
             chromaticAberration = false,
-            surfaceColor = Color.White.copy(alpha = 0.14f),
-            shadowEnabled = false,
+            surfaceColor = dockSurfaceColor,
+            shadowEnabled = lightDockGlass,
+            highlightEnabled = true,
+            clipToBounds = false,
             clickTargetEnabled = false,
             pressExpansion = 1.5.dp
         ) {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -3607,9 +3607,9 @@ fun EduImportBrowserScreen(
         }
     }
 
-    // The WebView producer extends behind the compact top bar so its gradient glass has real page
-    // pixels to sample. Messages, the unified Browser Dock and root-overlay popups remain later
-    // siblings outside the capture chain.
+    // The producer spans the whole window for the compact top bar, while the actual WebView is
+    // laid out below that bar. Messages, the unified Browser Dock and root-overlay popups remain
+    // later siblings outside the capture chain.
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -3620,6 +3620,7 @@ fun EduImportBrowserScreen(
                 AndroidView(
                     modifier = Modifier
                         .fillMaxSize()
+                        .padding(top = topPadding)
                         .graphicsLayer {
                             compositingStrategy = CompositingStrategy.Offscreen
                         },
@@ -3638,6 +3639,7 @@ fun EduImportBrowserScreen(
                     AndroidView(
                         modifier = Modifier
                             .fillMaxSize()
+                            .padding(top = topPadding)
                             .graphicsLayer {
                                 compositingStrategy = CompositingStrategy.Offscreen
                             },

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -278,6 +278,7 @@ import com.kyant.backdrop.catalog.components.LiquidPanel
 import com.kyant.backdrop.catalog.components.LiquidSlider
 import com.kyant.backdrop.catalog.components.LiquidToggle
 import com.kyant.backdrop.Backdrop
+import com.kyant.backdrop.backdrops.LayerBackdrop
 import com.xiaomanjun.sleepdownschedule.glass.GlassBackdropDomain
 import com.xiaomanjun.sleepdownschedule.glass.glassBackdropProducer
 import com.xiaomanjun.sleepdownschedule.glass.rememberGlassCombinedBackdrop
@@ -1888,7 +1889,7 @@ private fun EduAlphabetRailDock(
                 visible = showAlphabetRail,
                 modifier = Modifier
                     .align(Alignment.CenterEnd)
-                    .padding(end = 2.dp),
+                    .padding(end = 0.dp),
                 enter = fadeIn(tween(240)),
                 exit = fadeOut(tween(240))
             ) {
@@ -2632,6 +2633,7 @@ fun EduImportActivityScreen(
     state: AppState,
     adapter: EduAdapter,
     backdrop: Backdrop?,
+    webContentBackdrop: LayerBackdrop,
     useDetailTopPadding: Boolean = true,
     onParsed: (ImportDraft) -> Unit
 ) {
@@ -2694,6 +2696,7 @@ fun EduImportActivityScreen(
     EduImportBrowserScreen(
         state = state,
         adapter = adapter,
+        webContentBackdrop = webContentBackdrop,
         message = message,
         webView = webView,
         onWebView = { webView = it },
@@ -3034,6 +3037,7 @@ private fun eduDesktopUserAgent(context: Context): String {
 fun EduImportBrowserScreen(
     state: AppState,
     adapter: EduAdapter,
+    webContentBackdrop: LayerBackdrop,
     message: String?,
     webView: WebView?,
     onWebView: (WebView?) -> Unit,
@@ -3045,10 +3049,6 @@ fun EduImportBrowserScreen(
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
-    val webContentBackdrop = rememberGlassLayerBackdrop(
-        domain = GlassBackdropDomain.Content,
-        providerId = "edu-import-web-content"
-    )
     val buttonBackdrop = webContentBackdrop
     var addressText by remember(currentUrl) { mutableStateOf(currentUrl) }
     var canGoBack by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -3074,6 +3074,7 @@ fun EduImportBrowserScreen(
         onMessage(completed.error ?: completed.liveSummary.ifBlank { completed.steps.lastOrNull().orEmpty() })
     }
     val topPadding = if (useDetailTopPadding) detailContentTopPadding() else 0.dp
+    val webContentTopInsetPx = with(LocalDensity.current) { topPadding.roundToPx() }
     val normalizedUrl = remember(addressText) {
         normalizeEduUrl(addressText)
     }
@@ -3440,6 +3441,8 @@ fun EduImportBrowserScreen(
     fun configureEduWebView(target: WebView, isPopup: Boolean) {
         target.apply webView@ {
             setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null)
+            setPadding(0, webContentTopInsetPx, 0, 0)
+            clipToPadding = false
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.databaseEnabled = true
@@ -3607,9 +3610,9 @@ fun EduImportBrowserScreen(
         }
     }
 
-    // The producer spans the whole window for the compact top bar, while the actual WebView is
-    // laid out below that bar. Messages, the unified Browser Dock and root-overlay popups remain
-    // later siblings outside the capture chain.
+    // The producer and WebView span the whole window for the compact top bar. WebView's own top
+    // padding keeps the first page frame below the bar, then scrolls away with the page so content
+    // can continue beneath the gradient glass. Messages, the Browser Dock and popups stay outside.
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -3620,7 +3623,6 @@ fun EduImportBrowserScreen(
                 AndroidView(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(top = topPadding)
                         .graphicsLayer {
                             compositingStrategy = CompositingStrategy.Offscreen
                         },
@@ -3639,7 +3641,6 @@ fun EduImportBrowserScreen(
                     AndroidView(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(top = topPadding)
                             .graphicsLayer {
                                 compositingStrategy = CompositingStrategy.Offscreen
                             },

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -3438,11 +3438,23 @@ fun EduImportBrowserScreen(
         return true
     }
 
+    fun updateEduWebTopOffset(target: WebView, scrollY: Int = target.scrollY) {
+        if (webContentTopInsetPx <= 0) {
+            target.translationY = 0f
+            return
+        }
+        val collapseDistance = webContentTopInsetPx * 2.5f
+        val collapseProgress = (scrollY.coerceAtLeast(0) / collapseDistance).coerceIn(0f, 1f)
+        target.translationY = webContentTopInsetPx * (1f - collapseProgress)
+    }
+
     fun configureEduWebView(target: WebView, isPopup: Boolean) {
         target.apply webView@ {
             setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null)
-            setPadding(0, webContentTopInsetPx, 0, 0)
-            clipToPadding = false
+            updateEduWebTopOffset(this)
+            setOnScrollChangeListener { _, _, scrollY, _, _ ->
+                updateEduWebTopOffset(this, scrollY)
+            }
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.databaseEnabled = true
@@ -3480,6 +3492,7 @@ fun EduImportBrowserScreen(
 
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
+                    view?.let { updateEduWebTopOffset(it) }
                     val visiblePage = if (isPopup) popupWebView === view else popupWebView == null
                     if (visiblePage) updateNavigationState(view)
                     if (visiblePage && !url.isNullOrBlank()) {
@@ -3610,14 +3623,15 @@ fun EduImportBrowserScreen(
         }
     }
 
-    // The producer and WebView span the whole window for the compact top bar. WebView's own top
-    // padding keeps the first page frame below the bar, then scrolls away with the page so content
-    // can continue beneath the gradient glass. Messages, the Browser Dock and popups stay outside.
+    // The producer and unclipped WebView span the whole window. The complete WebView surface starts
+    // below the compact bar, then its translation collapses from real scrollY so fixed page headers
+    // remain intact and can move beneath the gradient glass. Dock and popups stay outside capture.
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .glassBackdropProducer(webContentBackdrop)
+                .background(MaterialTheme.colorScheme.background)
         ) {
             key(webViewGeneration) {
                 AndroidView(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -3607,9 +3607,10 @@ fun EduImportBrowserScreen(
         }
     }
 
-    // Only the native WebView is recorded into this dedicated backdrop. Messages, the unified
-    // Browser Dock and its root-overlay popups remain later siblings outside the capture chain.
-    Box(modifier = Modifier.fillMaxSize().padding(top = topPadding)) {
+    // The WebView producer extends behind the compact top bar so its gradient glass has real page
+    // pixels to sample. Messages, the unified Browser Dock and root-overlay popups remain later
+    // siblings outside the capture chain.
+    Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -3659,7 +3660,7 @@ fun EduImportBrowserScreen(
                 it,
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .padding(top = 10.dp, start = 16.dp, end = 16.dp)
+                    .padding(top = topPadding + 10.dp, start = 16.dp, end = 16.dp)
                     .clip(RoundedCornerShape(50))
                     .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.86f))
                     .padding(horizontal = 14.dp, vertical = 8.dp),

--- a/app/src/main/res/drawable/ic_web_mode.xml
+++ b/app/src/main/res/drawable/ic_web_mode.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M4,6h18V4H4c-1.1,0 -2,0.9 -2,2v11H0v3h14v-3H4V6zM23,8h-6c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h6c0.55,0 1,-0.45 1,-1V9c0,-0.55 -0.45,-1 -1,-1zM22,17h-4v-7h4v7z" />
+</vector>


### PR DESCRIPTION
## 完成

- 统一首页个性化、单节课编辑与课程管理的课程调色入口和当前颜色状态
- 修正教务学校页字母栏位置
- 恢复教务 Browser Dock 的液态玻璃高光、描边与阴影
- 将导入入口改为图标，并为导入/更多 Popup 增加语义图标
- 地址栏聚焦时，左右操作随系统 IME 动画进度非线性外移、动态模糊淡出，地址栏同步扩展；键盘收起时反向回缩
- 修复教务浏览器顶栏采样链，并启用成熟的渐变模糊与居中标题
- 选择学校页刷新按钮完整复用返回键的尺寸和玻璃参数
- WebView 与 producer 保持全屏，首屏通过 WebView 内部可滚动顶部 inset 避开顶栏；滚动后网页自然延伸到渐变模糊下方
- 放缓 Dock 避让动画前段速度，保持逐帧跟随系统 IME inset

## 验证

- `compileGithubReleaseKotlin` 通过
- `assembleGithubRelease` 通过（R8、资源压缩、lintVital 均开启）
- 最新签名 GitHub Release 已覆盖安装到 PLJ110，未自动启动

## 实机仍需确认

- 首屏内容避开顶栏、滚动后进入顶栏下方的连续性
- 顶栏在浅色/深色网页上的渐变模糊观感
- Dock 调整后的 IME 跟随节奏
- Popup 图标对齐与触摸区域