### PR TITLE
feat: host official Shiguang adapter runtime

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -190,6 +190,7 @@
             android:name=".EduImportActivity"
             android:exported="false"
             android:theme="@style/AppTheme"
+            android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".EduSchoolSelectActivity" />
         <activity
             android:name=".AiEduImportProgressActivity"

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -194,6 +194,7 @@ import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -6860,9 +6861,11 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
             val refreshScope = rememberCoroutineScope()
             var warehouseGeneration by remember { mutableIntStateOf(0) }
             var warehouseRefreshing by remember { mutableStateOf(false) }
+            var warehouseManualRefreshing by remember { mutableStateOf(false) }
             fun refreshWarehouse(manual: Boolean) {
                 if (warehouseRefreshing) return
                 warehouseRefreshing = true
+                warehouseManualRefreshing = manual
                 refreshScope.launch {
                     runCatching {
                         ShiguangWarehouseUpdater.refresh(this@EduSchoolSelectActivityHost)
@@ -6891,6 +6894,7 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                         }
                     }
                     warehouseRefreshing = false
+                    warehouseManualRefreshing = false
                 }
             }
             LaunchedEffect(Unit) {
@@ -6937,6 +6941,29 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                                 )
                             }
                         )
+                        SleepDownPickerDialog(
+                            show = warehouseManualRefreshing,
+                            title = "更新适配器",
+                            onDismissRequest = {},
+                            backdrop = backdrop,
+                            config = state.config,
+                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(14.dp)
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(24.dp),
+                                    strokeWidth = 2.5.dp
+                                )
+                                Text(
+                                    text = "正在获取最新适配列表",
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -26,6 +26,7 @@ import com.xiaomanjun.sleepdownschedule.domain.course.*
 import com.xiaomanjun.sleepdownschedule.feature.course.editor.*
 import com.xiaomanjun.sleepdownschedule.feature.importing.*
 import com.xiaomanjun.sleepdownschedule.feature.importing.shiguang.ShiguangWarehouseUpdater
+import com.xiaomanjun.sleepdownschedule.feature.importing.shiguang.uninstallShiguangRuntime
 
 import com.xiaomanjun.sleepdownschedule.core.identity.AppDistribution
 import com.xiaomanjun.sleepdownschedule.feature.backup.*
@@ -8963,7 +8964,7 @@ internal fun WebView.releaseSleepDownWebView(clearResourceCache: Boolean = true)
     // Resource cache can grow into tens of megabytes after repeated school-site imports.
     // Cookies and DOM storage are intentionally retained so login state is not lost.
     if (clearResourceCache) runCatching { clearCache(true) }
-    runCatching { detachEduImportBridge() }
+    runCatching { uninstallShiguangRuntime() }
     runCatching { destroy() }
 }
 

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/app/ui/ScheduleAppUi.kt
@@ -194,7 +194,6 @@ import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -6941,29 +6940,20 @@ open class EduSchoolSelectActivityHost : ComponentActivity() {
                                 )
                             }
                         )
-                        SleepDownPickerDialog(
-                            show = warehouseManualRefreshing,
-                            title = "更新适配器",
-                            onDismissRequest = {},
+                        LiquidAlertDialog(
+                            title = "正在更新适配器",
+                            message = "正在获取最新适配列表。现在可以返回或退到桌面，更新会在后台继续。",
+                            actions = listOf(
+                                LiquidAlertAction(
+                                    "后台继续",
+                                    LiquidAlertActionStyle.Secondary,
+                                    onClick = { warehouseManualRefreshing = false }
+                                )
+                            ),
                             backdrop = backdrop,
                             config = state.config,
-                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 6.dp)
-                        ) {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(14.dp)
-                            ) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(24.dp),
-                                    strokeWidth = 2.5.dp
-                                )
-                                Text(
-                                    text = "正在获取最新适配列表",
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            }
-                        }
+                            onDismissRequest = { warehouseManualRefreshing = false }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduImport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduImport.kt
@@ -1,25 +1,13 @@
 package com.xiaomanjun.sleepdownschedule.feature.importing
 
-import com.xiaomanjun.sleepdownschedule.*
 import com.xiaomanjun.sleepdownschedule.feature.importing.shiguang.ShiguangWarehouseUpdater
 
 import android.content.Context
-import android.os.Handler
-import android.os.Looper
-import android.webkit.JavascriptInterface
-import android.widget.Toast
-import org.json.JSONArray
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.json.Json
 import java.io.EOFException
 import java.io.IOException
 import java.security.MessageDigest
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
 
 data class EduSchool(
     val id: String,
@@ -36,7 +24,8 @@ data class EduAdapter(
     val assetJsPath: String,
     val importUrl: String,
     val maintainer: String,
-    val description: String
+    val description: String,
+    val warehouseGeneration: String = ""
 ) {
     val displayName: String = "${school.name} · $adapterName"
 }
@@ -78,7 +67,8 @@ fun EduAdapter.toIntentKey(): String = listOf(
     assetJsPath,
     importUrl,
     maintainer,
-    description
+    description,
+    warehouseGeneration
 ).joinToString("\u001F")
 
 fun eduAdapterFromIntentKey(value: String?): EduAdapter? {
@@ -92,7 +82,8 @@ fun eduAdapterFromIntentKey(value: String?): EduAdapter? {
         assetJsPath = parts[7],
         importUrl = parts[8],
         maintainer = parts[9],
-        description = parts[10]
+        description = parts[10],
+        warehouseGeneration = parts.getOrElse(11) { "" }
     )
 }
 
@@ -106,18 +97,6 @@ fun EduAdapter.isAiEduImportTool(): Boolean {
 
 fun EduAdapter.requiresManualEduUrl(): Boolean {
     return isAiEduImportTool()
-}
-
-fun EduAdapter.isEduTestTool(): Boolean {
-    return school.id == "GLOBAL_TOOLS" && adapterId == "GENERAL_TOOL_01"
-}
-
-fun EduAdapter.isWakeUpImportTool(): Boolean {
-    return school.id == "GLOBAL_TOOLS" && adapterId.equals("WakeUp", ignoreCase = true)
-}
-
-fun EduAdapter.isStarLinkImportTool(): Boolean {
-    return school.id == "GLOBAL_TOOLS" && adapterId.equals("StarLink", ignoreCase = true)
 }
 
 fun aiEduImportAdapter(): EduAdapter = EduAdapter(
@@ -286,6 +265,7 @@ object ShiguangWarehouse {
             "不支持的拾光仓库索引协议：v$protocolVersion（需要 v$ProtocolV2）"
         }
         require(schools.isNotEmpty()) { "拾光仓库 v2 索引中没有学校数据" }
+        val indexSha = bytes.sha256Hex()
         val adapters = schools.flatMap { record ->
             val school = EduSchool(
                 id = record.id,
@@ -302,7 +282,8 @@ object ShiguangWarehouse {
                     assetJsPath = adapter.assetJsPath,
                     importUrl = adapter.importUrl,
                     maintainer = adapter.maintainer,
-                    description = adapter.description
+                    description = adapter.description,
+                    warehouseGeneration = indexSha
                 )
             }
         }
@@ -310,7 +291,7 @@ object ShiguangWarehouse {
         return ShiguangWarehouseSnapshot(
             protocolVersion = protocolVersion,
             versionId = versionId,
-            indexSha = bytes.sha256Hex(),
+            indexSha = indexSha,
             adapters = adapters
         )
     }
@@ -465,353 +446,3 @@ internal data class ShiguangWarehouseSnapshot(
     val indexSha: String,
     val adapters: List<EduAdapter>
 )
-
-class EduImportBridge(
-    private val context: Context,
-    private val adapter: EduAdapter? = null,
-    private val baseConfig: () -> ScheduleConfigEntity,
-    private val basePeriods: () -> List<PeriodEntity> = { defaultPeriods() },
-    private val onDraft: (ImportDraft) -> Unit,
-    private val onMessage: (String) -> Unit,
-    private val onInteractionRequest: (EduBridgeInteractionRequest) -> Unit = {},
-    private val onTaskCompleted: () -> Unit = {}
-) {
-    private val mainHandler = Handler(Looper.getMainLooper())
-    private val taskLock = Any()
-    private var configJson: String? = null
-    private var coursesJson: String? = null
-    private var timeSlotsJson: String? = null
-    private var completionDelivered: Boolean = false
-
-    fun beginTask() {
-        synchronized(taskLock) {
-            configJson = null
-            coursesJson = null
-            timeSlotsJson = null
-            completionDelivered = false
-        }
-    }
-
-    @JavascriptInterface
-    fun saveCourseConfig(json: String): Boolean {
-        synchronized(taskLock) { configJson = json }
-        return true
-    }
-
-    @JavascriptInterface
-    fun saveImportedCourses(json: String): Boolean {
-        synchronized(taskLock) { coursesJson = json }
-        return true
-    }
-
-    @JavascriptInterface
-    fun savePresetTimeSlots(json: String): Boolean {
-        synchronized(taskLock) { timeSlotsJson = json }
-        return true
-    }
-
-    @JavascriptInterface
-    fun notifyTaskCompletion() {
-        val payload = synchronized(taskLock) {
-            if (completionDelivered) return
-            completionDelivered = true
-            Triple(configJson, coursesJson, timeSlotsJson ?: "[]")
-        }
-        val (config, courses, slots) = payload
-        if (courses == null) {
-            mainHandler.post {
-                try {
-                    onMessage("导入脚本没有返回课程数据，可以尝试 AI 兜底扒页。")
-                } finally {
-                    runCatching(onTaskCompleted)
-                }
-            }
-            return
-        }
-        runCatching {
-            ShiguangImportMapper.toDraft(adapter, baseConfig(), basePeriods(), config ?: "{}", courses, slots)
-        }.onSuccess {
-            mainHandler.post {
-                try {
-                    onDraft(it)
-                } finally {
-                    runCatching(onTaskCompleted)
-                }
-            }
-        }.onFailure {
-            mainHandler.post {
-                try {
-                    onMessage(it.message ?: "教务数据解析失败")
-                } finally {
-                    runCatching(onTaskCompleted)
-                }
-            }
-        }
-    }
-
-    /** Terminates a script-driven import without fabricating an empty course payload. */
-    @JavascriptInterface
-    fun reportTaskFailure(message: String?) {
-        synchronized(taskLock) {
-            if (completionDelivered) return
-            completionDelivered = true
-        }
-        mainHandler.post {
-            try {
-                onMessage(message?.takeIf { it.isNotBlank() } ?: "导入脚本执行失败")
-            } finally {
-                runCatching(onTaskCompleted)
-            }
-        }
-    }
-
-    @JavascriptInterface
-    fun showToast(message: String) {
-        mainHandler.post {
-            Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
-            onMessage(message)
-        }
-    }
-
-    @JavascriptInterface
-    fun requestAlert(requestId: String, title: String?, message: String?, confirmText: String?) {
-        mainHandler.post {
-            onInteractionRequest(
-                EduBridgeInteractionRequest.Alert(
-                    requestId = requestId,
-                    title = title.orEmpty().ifBlank { "提示" },
-                    message = message.orEmpty(),
-                    confirmText = confirmText.orEmpty().ifBlank { "确定" }
-                )
-            )
-        }
-    }
-
-    @JavascriptInterface
-    fun requestPrompt(
-        requestId: String,
-        title: String?,
-        message: String?,
-        defaultValue: String?,
-        validator: String?
-    ) {
-        mainHandler.post {
-            onInteractionRequest(
-                EduBridgeInteractionRequest.Prompt(
-                    requestId = requestId,
-                    title = title.orEmpty().ifBlank { "请输入" },
-                    message = message.orEmpty(),
-                    defaultValue = defaultValue.orEmpty(),
-                    validator = validator?.takeIf { it.isNotBlank() }
-                )
-            )
-        }
-    }
-
-    @JavascriptInterface
-    fun requestSingleSelection(
-        requestId: String,
-        title: String?,
-        optionsJson: String?,
-        defaultIndex: Int
-    ) {
-        val options = runCatching {
-            val array = JSONArray(optionsJson ?: "[]")
-            List(array.length()) { index -> array.optString(index) }
-        }.getOrDefault(emptyList())
-        mainHandler.post {
-            onInteractionRequest(
-                EduBridgeInteractionRequest.SingleSelection(
-                    requestId = requestId,
-                    title = title.orEmpty().ifBlank { "请选择" },
-                    options = options,
-                    defaultIndex = defaultIndex.takeIf { it in options.indices } ?: -1
-                )
-            )
-        }
-    }
-}
-
-object ShiguangImportMapper {
-    private val json = Json { ignoreUnknownKeys = true }
-
-    fun toDraft(
-        adapter: EduAdapter?,
-        baseConfig: ScheduleConfigEntity,
-        basePeriods: List<PeriodEntity>,
-        configJson: String,
-        coursesJson: String,
-        timeSlotsJson: String
-    ): ImportDraft {
-        val config = json.decodeFromString(ShiguangCourseConfig.serializer(), configJson)
-        val slots = json.decodeFromString(ListSerializer(ShiguangTimeSlot.serializer()), timeSlotsJson)
-        val courses = json.decodeFromString(ListSerializer(ShiguangCourse.serializer()), coursesJson)
-        val basePeriodMap = basePeriods.ifEmpty { defaultPeriods() }.associateBy { it.periodIndex }
-        val importedPeriods = slots.mapNotNull {
-            val number = it.number ?: return@mapNotNull null
-            val start = it.startTime.orEmpty()
-            val end = it.endTime.orEmpty()
-            if (start.isBlank() || end.isBlank()) return@mapNotNull null
-            if (!isPlausibleImportedPeriod(start, end, baseConfig.classDurationMinutes)) return@mapNotNull null
-            if (basePeriodMap[number]?.let { base -> isLikelyWrongImportedPeriod(number, start, end, base) } == true) return@mapNotNull null
-            PeriodEntity(number, start, end)
-        }.distinctBy { it.periodIndex }.sortedBy { it.periodIndex }
-        val totalWeeks = (config.totalWeeks ?: config.semesterTotalWeeks ?: courses.flatMap { it.normalizedWeeks() }.maxOrNull() ?: baseConfig.totalWeeks).coerceAtLeast(1)
-        val mappedCourses = courses.mapNotNull { course ->
-            val day = course.day ?: course.dayOfWeek ?: course.weekday ?: return@mapNotNull null
-            val sectionRange = course.normalizedSections() ?: return@mapNotNull null
-            val weeks = course.normalizedWeeks().filter { it > 0 }.ifEmpty { (1..totalWeeks).toList() }
-            CourseEntity(
-                name = (course.name ?: course.courseName).orEmpty().ifBlank { "未命名课程" },
-                teacher = (course.teacher ?: course.teachers?.joinToString("、"))?.ifBlank { null },
-                location = (course.position ?: course.classroom ?: course.location ?: course.room)?.ifBlank { null },
-                weekday = day.coerceIn(1, 7),
-                periods = (sectionRange.first..sectionRange.last).toList(),
-                weeks = weeks,
-                weekParity = WeekParity.ALL,
-                note = null
-            )
-        }
-        val maxCoursePeriod = mappedCourses.flatMap { it.periods }.maxOrNull() ?: 0
-        val forcedPeriods = forcedSchoolPeriods(adapter)
-        val periods = expandImportedPeriods(
-            imported = if (forcedPeriods != null) emptyList() else importedPeriods,
-            base = forcedPeriods ?: basePeriods.ifEmpty { defaultPeriods() },
-            requiredMaxPeriod = maxCoursePeriod,
-            classDurationMinutes = baseConfig.classDurationMinutes,
-            breakDurationMinutes = baseConfig.breakDurationMinutes
-        )
-        return ImportDraft(
-            config = baseConfig.copy(
-                totalWeeks = totalWeeks,
-                termStartDate = config.semesterStartDate ?: baseConfig.termStartDate
-            ),
-            periods = periods,
-            courses = mappedCourses
-        )
-    }
-}
-
-private fun forcedSchoolPeriods(adapter: EduAdapter?): List<PeriodEntity>? {
-    if (adapter?.school?.id != "SWU") return null
-    return listOf(
-        PeriodEntity(1, "08:00", "08:45"),
-        PeriodEntity(2, "08:55", "09:40"),
-        PeriodEntity(3, "10:00", "10:45"),
-        PeriodEntity(4, "10:55", "11:40"),
-        PeriodEntity(5, "12:10", "12:55"),
-        PeriodEntity(6, "13:05", "13:50"),
-        PeriodEntity(7, "14:00", "14:45"),
-        PeriodEntity(8, "14:55", "15:40"),
-        PeriodEntity(9, "15:50", "16:35"),
-        PeriodEntity(10, "16:55", "17:40"),
-        PeriodEntity(11, "17:50", "18:35"),
-        PeriodEntity(12, "19:20", "20:05"),
-        PeriodEntity(13, "20:15", "21:00"),
-        PeriodEntity(14, "21:10", "21:55")
-    )
-}
-
-private val importTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
-
-private fun isPlausibleImportedPeriod(start: String, end: String, classDurationMinutes: Int): Boolean {
-    val startTime = runCatching { LocalTime.parse(start, importTimeFormatter) }.getOrNull() ?: return false
-    val endTime = runCatching { LocalTime.parse(end, importTimeFormatter) }.getOrNull() ?: return false
-    val minutes = java.time.Duration.between(startTime, endTime).toMinutes()
-    val expected = classDurationMinutes.coerceIn(1, 300)
-    return minutes in 1..maxOf(90, expected * 2)
-}
-
-private fun isLikelyWrongImportedPeriod(index: Int, start: String, end: String, base: PeriodEntity): Boolean {
-    val importedStart = runCatching { LocalTime.parse(start, importTimeFormatter) }.getOrNull() ?: return true
-    val importedEnd = runCatching { LocalTime.parse(end, importTimeFormatter) }.getOrNull() ?: return true
-    val baseStart = runCatching { LocalTime.parse(base.startTime, importTimeFormatter) }.getOrNull() ?: return false
-    val baseEnd = runCatching { LocalTime.parse(base.endTime, importTimeFormatter) }.getOrNull() ?: return false
-    val startOffset = kotlin.math.abs(java.time.Duration.between(baseStart, importedStart).toMinutes())
-    val endOffset = kotlin.math.abs(java.time.Duration.between(baseEnd, importedEnd).toMinutes())
-    return index >= 10 && (startOffset > 90 || endOffset > 90)
-}
-
-private fun expandImportedPeriods(
-    imported: List<PeriodEntity>,
-    base: List<PeriodEntity>,
-    requiredMaxPeriod: Int,
-    classDurationMinutes: Int,
-    breakDurationMinutes: Int
-): List<PeriodEntity> {
-    val hasImportedPeriods = imported.isNotEmpty()
-    val targetMax = if (hasImportedPeriods) {
-        maxOf(requiredMaxPeriod, imported.maxOfOrNull { it.periodIndex } ?: 0)
-    } else {
-        maxOf(requiredMaxPeriod, base.maxOfOrNull { it.periodIndex } ?: 0)
-    }
-    if (targetMax <= 0) return defaultPeriods()
-    val importedByIndex = imported.associateBy { it.periodIndex }
-    val baseByIndex = base.associateBy { it.periodIndex }
-    val result = mutableListOf<PeriodEntity>()
-    for (index in 1..targetMax) {
-        val existing = importedByIndex[index] ?: baseByIndex[index]
-        if (existing != null) {
-            result += existing
-        } else {
-            result += buildNextPeriod(index, result.lastOrNull(), classDurationMinutes, breakDurationMinutes)
-        }
-    }
-    return result
-}
-
-private fun buildNextPeriod(index: Int, previous: PeriodEntity?, classDurationMinutes: Int, breakDurationMinutes: Int): PeriodEntity {
-    val duration = classDurationMinutes.coerceIn(1, 300).toLong()
-    val breakDuration = breakDurationMinutes.coerceIn(0, 300).toLong()
-    val start = previous?.endTime
-        ?.let { runCatching { LocalTime.parse(it, importTimeFormatter).plusMinutes(breakDuration) }.getOrNull() }
-        ?: LocalTime.of(8, 0).plusMinutes((index - 1).coerceAtLeast(0).toLong() * (duration + breakDuration))
-    val end = start.plusMinutes(duration)
-    return PeriodEntity(index, start.format(importTimeFormatter), end.format(importTimeFormatter))
-}
-
-@Serializable
-data class ShiguangCourseConfig(
-    val semesterStartDate: String? = null,
-    val totalWeeks: Int? = null,
-    val semesterTotalWeeks: Int? = null
-)
-
-@Serializable
-data class ShiguangTimeSlot(
-    val number: Int? = null,
-    val startTime: String? = null,
-    val endTime: String? = null
-)
-
-@Serializable
-data class ShiguangCourse(
-    val name: String? = null,
-    val courseName: String? = null,
-    val teacher: String? = null,
-    val teachers: List<String>? = null,
-    val position: String? = null,
-    val location: String? = null,
-    val room: String? = null,
-    val day: Int? = null,
-    val dayOfWeek: Int? = null,
-    val weekday: Int? = null,
-    val startSection: Int? = null,
-    val endSection: Int? = null,
-    val sections: List<Int>? = null,
-    val weeks: List<Int>? = null,
-    val weekList: List<Int>? = null,
-    @SerialName("classroom") val classroom: String? = null
-)
-
-private fun ShiguangCourse.normalizedSections(): IntRange? {
-    val fromList = sections?.filter { it > 0 }?.sorted()
-    if (!fromList.isNullOrEmpty()) return fromList.first()..fromList.last()
-    val start = startSection ?: return null
-    val end = endSection ?: start
-    return minOf(start, end)..maxOf(start, end)
-}
-
-private fun ShiguangCourse.normalizedWeeks(): List<Int> {
-    return (weeks ?: weekList).orEmpty()
-}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduImport.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduImport.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.io.EOFException
 import java.io.IOException
+import java.security.MessageDigest
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
@@ -96,7 +97,7 @@ fun eduAdapterFromIntentKey(value: String?): EduAdapter? {
 }
 
 fun EduAdapter.isGeneralEduTool(): Boolean {
-    return school.id in setOf("zhengfang_jiaowu", "chaoxing_jiaowu", "qingguo_jiaowu", "urp_jiaowu")
+    return category == "GENERAL_TOOL"
 }
 
 fun EduAdapter.isAiEduImportTool(): Boolean {
@@ -104,7 +105,7 @@ fun EduAdapter.isAiEduImportTool(): Boolean {
 }
 
 fun EduAdapter.requiresManualEduUrl(): Boolean {
-    return isGeneralEduTool() || isAiEduImportTool()
+    return isAiEduImportTool()
 }
 
 fun EduAdapter.isEduTestTool(): Boolean {
@@ -141,32 +142,34 @@ object ShiguangWarehouse {
     private val quotedValue = Regex("""^\s*([A-Za-z_]+):\s*"?(.*?)"?\s*(?:#.*)?$""")
 
     fun loadAdapters(context: Context): List<EduAdapter> {
-        val protocolAdapters = runCatching {
+        val officialAdapters = runCatching {
             ShiguangWarehouseUpdater.cachedIndexFile(context)
                 .takeIf { it.isFile }
                 ?.readBytes()
-                ?.let(::parseProtocolV2Index)
+                ?.let(::parseProtocolV2Snapshot)
+                ?.adapters
                 ?.takeIf { it.isNotEmpty() }
         }.getOrNull() ?: loadBundledAdapters(context)
-        // Preserve bundled private adaptations that are not published by the official index.
-        val protocolSchoolIds = protocolAdapters.map { it.school.id }.toSet()
-        val warehouseAdapters = (
-            protocolAdapters + loadLegacyYamlAdapters(context).filter { it.school.id !in protocolSchoolIds }
-            ).map { adapter ->
-            if (adapter.isEduTestTool()) adapter.copy(importUrl = EDU_BRIDGE_TEST_PAGE_URL) else adapter
-        }.filter { it.assetJsPath.isNotBlank() && (it.importUrl.isNotBlank() || it.isGeneralEduTool()) }
+        val warehouseAdapters = officialAdapters
+            .filter { it.category in OfficialCategories }
             .sortedWith(compareBy<EduAdapter> { it.school.initial }.thenBy { it.school.name }.thenBy { it.adapterName })
         return listOf(aiEduImportAdapter()) + warehouseAdapters
     }
 
-    private fun loadBundledAdapters(context: Context): List<EduAdapter> = runCatching {
-        context.assets.open("$Root/school_index.pb").use { input ->
-            parseProtocolV2Index(input.readBytes())
-        }
-    }.getOrElse {
-        // YAML remains the bundled compatibility fallback for snapshots without a valid v2 index.
-        loadLegacyYamlAdapters(context)
+    private fun loadBundledAdapters(context: Context): List<EduAdapter> {
+        val protocolAdapters = runCatching {
+            context.assets.open("$Root/school_index.pb").use { input ->
+                parseProtocolV2Snapshot(input.readBytes()).adapters
+            }
+        }.getOrNull()
+        return protocolAdapters?.takeIf { it.isNotEmpty() } ?: loadLegacyYamlAdapters(context)
     }
+
+    private val OfficialCategories = setOf(
+        "GENERAL_TOOL",
+        "BACHELOR_AND_ASSOCIATE",
+        "POSTGRADUATE"
+    )
 
     private fun loadLegacyYamlAdapters(context: Context): List<EduAdapter> {
         val schools = parseSchools(
@@ -186,12 +189,6 @@ object ShiguangWarehouse {
 
     suspend fun resolveScript(context: Context, adapter: EduAdapter): String = withContext(Dispatchers.IO) {
         val relativePath = ShiguangWarehouseUpdater.resourceRelativePath(adapter)
-        ShiguangWarehouseUpdater.cachedScriptFile(context, adapter)
-            .takeIf { it.isFile }
-            ?.readText()
-            ?.takeIf { it.isNotBlank() }
-            ?.let { return@withContext it }
-
         var remoteFailure: Exception? = null
         if (ShiguangWarehouseUpdater.hasValidRemoteIndex(context)) {
             try {
@@ -270,16 +267,17 @@ object ShiguangWarehouse {
         return result
     }
 
-    /** Parses the official shiguang_warehouse protocol-v2 protobuf without a codegen runtime. */
-    internal fun parseProtocolV2Index(bytes: ByteArray): List<EduAdapter> {
+    /** Parses one immutable official protocol-v2 warehouse snapshot. */
+    internal fun parseProtocolV2Snapshot(bytes: ByteArray): ShiguangWarehouseSnapshot {
         val reader = ProtoReader(bytes)
         var protocolVersion = 0
+        var versionId = ""
         val schools = mutableListOf<ProtocolSchool>()
         while (!reader.exhausted) {
             val tag = reader.readTag()
             when (tag.fieldNumber) {
                 1 -> protocolVersion = reader.readInt32(tag.wireType)
-                2 -> reader.readString(tag.wireType) // version_id is informational at runtime.
+                2 -> versionId = reader.readString(tag.wireType)
                 3 -> schools += parseProtocolSchool(reader.readMessage(tag.wireType))
                 else -> reader.skip(tag.wireType)
             }
@@ -288,7 +286,7 @@ object ShiguangWarehouse {
             "不支持的拾光仓库索引协议：v$protocolVersion（需要 v$ProtocolV2）"
         }
         require(schools.isNotEmpty()) { "拾光仓库 v2 索引中没有学校数据" }
-        return schools.flatMap { record ->
+        val adapters = schools.flatMap { record ->
             val school = EduSchool(
                 id = record.id,
                 name = record.name,
@@ -308,6 +306,13 @@ object ShiguangWarehouse {
                 )
             }
         }
+        require(adapters.isNotEmpty()) { "拾光仓库 v2 索引中没有适配器" }
+        return ShiguangWarehouseSnapshot(
+            protocolVersion = protocolVersion,
+            versionId = versionId,
+            indexSha = bytes.sha256Hex(),
+            adapters = adapters
+        )
     }
 
     private fun parseProtocolSchool(reader: ProtoReader): ProtocolSchool {
@@ -448,7 +453,18 @@ object ShiguangWarehouse {
             error("拾光仓库 v2 索引包含过长的 varint")
         }
     }
+
+    private fun ByteArray.sha256Hex(): String = MessageDigest.getInstance("SHA-256")
+        .digest(this)
+        .joinToString("") { byte -> "%02x".format(byte) }
 }
+
+internal data class ShiguangWarehouseSnapshot(
+    val protocolVersion: Int,
+    val versionId: String,
+    val indexSha: String,
+    val adapters: List<EduAdapter>
+)
 
 class EduImportBridge(
     private val context: Context,

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduWebSecurity.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/EduWebSecurity.kt
@@ -1,98 +1,7 @@
 package com.xiaomanjun.sleepdownschedule.feature.importing
 
-import com.xiaomanjun.sleepdownschedule.*
-
 import android.annotation.SuppressLint
 import android.webkit.WebView
-
-internal const val EDU_BRIDGE_TEST_PAGE_URL =
-    "file:///android_asset/shiguang_warehouse-main/resources/GLOBAL_TOOLS/test_page.html"
-
-internal val EDU_BRIDGE_PROMISE_BOOTSTRAP = """
-    (function () {
-        var nativeBridge = window.AndroidBridge;
-        var requestBridge = window.SleepDownBridgeRequests;
-        if (!nativeBridge || !requestBridge) {
-            throw new Error("SleepDown import bridge is unavailable");
-        }
-        var pending = Object.create(null);
-        var nextRequestId = 0;
-        function nullableString(value) {
-            return value == null ? null : String(value);
-        }
-        function enqueue(start) {
-            return new Promise(function (resolve, reject) {
-                var requestId = String(Date.now()) + "-" + String(++nextRequestId);
-                pending[requestId] = { resolve: resolve, reject: reject };
-                try {
-                    start(requestId);
-                } catch (error) {
-                    delete pending[requestId];
-                    reject(error);
-                }
-            });
-        }
-        window.__sleepDownBridgeResolve = function (requestId, value) {
-            var entry = pending[String(requestId)];
-            if (!entry) return false;
-            delete pending[String(requestId)];
-            entry.resolve(value);
-            return true;
-        };
-        window.__sleepDownBridgeReject = function (requestId, message) {
-            var entry = pending[String(requestId)];
-            if (!entry) return false;
-            delete pending[String(requestId)];
-            entry.reject(new Error(message || "Import interaction cancelled"));
-            return true;
-        };
-        window.AndroidBridgePromise = {
-            saveCourseConfig: function (json) {
-                return Promise.resolve(nativeBridge.saveCourseConfig(json));
-            },
-            saveImportedCourses: function (json) {
-                return Promise.resolve(nativeBridge.saveImportedCourses(json));
-            },
-            savePresetTimeSlots: function (json) {
-                return Promise.resolve(nativeBridge.savePresetTimeSlots(json));
-            },
-            showAlert: function (title, message, confirmText) {
-                return enqueue(function (requestId) {
-                    requestBridge.requestAlert(
-                        requestId,
-                        nullableString(title),
-                        nullableString(message),
-                        nullableString(confirmText)
-                    );
-                });
-            },
-            showPrompt: function (title, message, defaultValue, validator) {
-                return enqueue(function (requestId) {
-                    requestBridge.requestPrompt(
-                        requestId,
-                        nullableString(title),
-                        nullableString(message),
-                        nullableString(defaultValue),
-                        nullableString(validator)
-                    );
-                });
-            },
-            showSingleSelection: function (title, optionsJson, defaultIndex) {
-                return enqueue(function (requestId) {
-                    requestBridge.requestSingleSelection(
-                        requestId,
-                        nullableString(title),
-                        nullableString(optionsJson),
-                        Number.isInteger(defaultIndex) ? defaultIndex : -1
-                    );
-                });
-            }
-        };
-        window.shiguangBridge = nativeBridge;
-        window.shiguangBridgePromise = window.AndroidBridgePromise;
-        return true;
-    })();
-""".trimIndent()
 
 internal fun normalizeEduUrl(input: String): String {
     val trimmed = input.trim()
@@ -100,7 +9,6 @@ internal fun normalizeEduUrl(input: String): String {
         trimmed.isBlank() ||
             trimmed.equals("http://", ignoreCase = true) ||
             trimmed.equals("https://", ignoreCase = true) -> ""
-        trimmed.equals(EDU_BRIDGE_TEST_PAGE_URL, ignoreCase = true) -> EDU_BRIDGE_TEST_PAGE_URL
         trimmed.startsWith("http://", ignoreCase = true) ||
             trimmed.startsWith("https://", ignoreCase = true) -> trimmed
         ExplicitUriScheme.containsMatchIn(trimmed) -> ""
@@ -111,20 +19,7 @@ internal fun normalizeEduUrl(input: String): String {
 private val ExplicitUriScheme = Regex("^[A-Za-z][A-Za-z0-9+.-]*:")
 
 @SuppressLint("SetJavaScriptEnabled")
-internal fun WebView.configureEduImportSecurity(adapter: EduAdapter) {
+internal fun WebView.configureEduImportSecurity() {
     settings.allowContentAccess = false
-    settings.allowFileAccess = adapter.isEduTestTool()
-}
-
-@SuppressLint("JavascriptInterface")
-internal fun WebView.attachEduImportBridge(bridge: EduImportBridge) {
-    detachEduImportBridge()
-    addJavascriptInterface(bridge, "AndroidBridge")
-    addJavascriptInterface(bridge, "SleepDownBridgeRequests")
-}
-
-internal fun WebView.detachEduImportBridge() {
-    removeJavascriptInterface("AndroidBridgePromise")
-    removeJavascriptInterface("AndroidBridge")
-    removeJavascriptInterface("SleepDownBridgeRequests")
+    settings.allowFileAccess = false
 }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -4,6 +4,7 @@ import com.xiaomanjun.sleepdownschedule.app.ui.*
 import com.xiaomanjun.sleepdownschedule.core.ui.designsystem.*
 import com.xiaomanjun.sleepdownschedule.core.ui.settings.LocalDetailActivityFloatingOverlayHost
 import com.xiaomanjun.sleepdownschedule.feature.importing.history.*
+import com.xiaomanjun.sleepdownschedule.feature.importing.shiguang.*
 import com.xiaomanjun.sleepdownschedule.glass.ui.*
 import com.xiaomanjun.sleepdownschedule.feature.home.*
 import com.xiaomanjun.sleepdownschedule.feature.home.day.*
@@ -347,113 +348,6 @@ data class AiImportHistoryBackgroundCapture(
     val rootTopInWindow: Float
 )
 
-private val WakeUpLabelledKey = Regex(
-    "分享口令(?:为)?\\s*[「“\\\"]?\\s*([A-Za-z0-9_-]{8,200})\\s*[」”\\\"]?",
-    setOf(RegexOption.IGNORE_CASE)
-)
-private val WakeUpBareKey = Regex("^[A-Za-z0-9_-]{8,200}$")
-private val StarLinkStructuredCode = Regex(
-    "(?:星链|StarLink|输入[:：])[^A-Za-z0-9-]*([A-Za-z0-9-]{5,20})",
-    setOf(RegexOption.IGNORE_CASE)
-)
-private val StarLinkBareCode = Regex("^[A-Za-z0-9-]{5,20}$")
-
-private fun extractWakeUpShareKey(value: String): String? {
-    val text = value.trim()
-    if (text.isBlank()) return null
-    WakeUpLabelledKey.find(text)?.groupValues?.getOrNull(1)?.let { return it }
-    if (text.contains("wakeup", ignoreCase = true)) {
-        Regex("[A-Za-z0-9_-]{8,200}").findAll(text).lastOrNull()?.value?.let { return it }
-    }
-    return text.takeIf(WakeUpBareKey::matches)
-}
-
-private fun extractStarLinkShareCode(value: String): String? {
-    val text = value.trim()
-    if (text.isBlank()) return null
-    return StarLinkStructuredCode.find(text)?.groupValues?.getOrNull(1)
-        ?: text.takeIf(StarLinkBareCode::matches)
-}
-
-private fun buildWakeUpInlineImportScript(source: String, input: String): String {
-    val libraryOnly = source.replace(
-        Regex("(?m)^\\s*runImportFlow\\(\\);\\s*$"),
-        ""
-    )
-    val inputLiteral = JSONObject.quote(input)
-    return """
-        window.shiguangBridge = window.AndroidBridge;
-        window.shiguangBridgePromise = window.AndroidBridgePromise;
-        $libraryOnly
-        (async function sleepDownWakeUpInlineImport() {
-            try {
-                const rawInput = $inputLiteral;
-                const shareKey = extractKeyFromText(rawInput);
-                const validationError = validateKey(shareKey);
-                if (validationError) throw new Error(validationError);
-                const parsed = await fetchAndParseData(shareKey);
-                if (!parsed) throw new Error("WakeUP 没有返回可导入的课表数据。");
-                if (!await saveTimeSlots(parsed.timeSlots)) throw new Error("WakeUP 节次保存失败。");
-                if (!await saveConfig(parsed.courseConfig)) throw new Error("WakeUP 配置保存失败。");
-                if (!await saveCourses(parsed.courses)) throw new Error("WakeUP 课程保存失败。");
-                window.AndroidBridge.notifyTaskCompletion();
-            } catch (error) {
-                const message = error && error.message ? error.message : String(error);
-                window.AndroidBridge.reportTaskFailure("WakeUp 口令解析失败：" + message);
-            }
-        })();
-    """.trimIndent()
-}
-
-private fun buildStarLinkInlineImportScript(source: String, input: String): String {
-    val libraryOnly = source.replace(
-        Regex("(?m)^\\s*runStarlinkImport\\(\\);\\s*$"),
-        ""
-    )
-    val inputLiteral = JSONObject.quote(input)
-    return """
-        window.shiguangBridge = window.AndroidBridge;
-        window.shiguangBridgePromise = window.AndroidBridgePromise;
-        $libraryOnly
-        (async function sleepDownStarLinkInlineImport() {
-            try {
-                const rawInput = $inputLiteral;
-                const validationError = validateInput(rawInput);
-                if (validationError) throw new Error(validationError);
-                const shareCode = extractShareCode(rawInput);
-                const response = await fetch(`https://api.starlinkkb.cn/share/curriculum/${'$'}{shareCode}`);
-                if (!response.ok) throw new Error("分享码已失效或网络异常");
-                const resJson = await response.json();
-                const data = resJson && resJson.data;
-                if (!data || !Array.isArray(data.courses)) throw new Error("星链没有返回课程数据");
-                const rawCourses = data.courses.map(c => ({
-                    name: c.name,
-                    teacher: (c.teacher && c.teacher !== "无") ? c.teacher : "未知",
-                    position: (c.location && c.location.replace(/^@/, '').trim() !== "")
-                        ? c.location.replace(/^@/, '').trim()
-                        : "未排地点",
-                    day: c.weekday,
-                    startSection: c.startSection,
-                    endSection: c.endSection,
-                    weeks: c.weeks
-                }));
-                const finalCourses = processAndMergeCourses(rawCourses);
-                const config = {
-                    semesterStartDate: data.startDate ? data.startDate.substring(0, 10) : null,
-                    semesterTotalWeeks: data.totalWeeks || 20
-                };
-                await window.AndroidBridgePromise.saveCourseConfig(JSON.stringify(config));
-                const success = await window.AndroidBridgePromise.saveImportedCourses(JSON.stringify(finalCourses));
-                if (!success) throw new Error("星链课程保存失败");
-                window.AndroidBridge.notifyTaskCompletion();
-            } catch (error) {
-                const message = error && error.message ? error.message : String(error);
-                window.AndroidBridge.reportTaskFailure("星链口令解析失败：" + message);
-            }
-        })();
-    """.trimIndent()
-}
-
 @Composable
 fun NormalizedAiManualImportScreen(
     state: AppState,
@@ -472,10 +366,6 @@ fun NormalizedAiManualImportScreen(
     var routeMessage by remember { mutableStateOf<String?>(null) }
     var selectedFileName by remember { mutableStateOf<String?>(null) }
     var aiParsing by remember { mutableStateOf(false) }
-    var wakeUpImportInput by remember { mutableStateOf<String?>(null) }
-    var wakeUpWebView by remember { mutableStateOf<WebView?>(null) }
-    var starLinkImportInput by remember { mutableStateOf<String?>(null) }
-    var starLinkWebView by remember { mutableStateOf<WebView?>(null) }
     var showAiTokenRepairPrompt by remember { mutableStateOf(false) }
     var selectedMode by remember { mutableIntStateOf(0) }
     var aiSettings by remember { mutableStateOf(AiImportSettingsStore.load(context)) }
@@ -497,178 +387,6 @@ fun NormalizedAiManualImportScreen(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
-    DisposableEffect(Unit) {
-        onDispose {
-            wakeUpWebView?.releaseSleepDownWebView(clearResourceCache = false)
-            wakeUpWebView = null
-            starLinkWebView?.releaseSleepDownWebView(clearResourceCache = false)
-            starLinkWebView = null
-        }
-    }
-    LaunchedEffect(wakeUpImportInput) {
-        val input = wakeUpImportInput ?: return@LaunchedEffect
-        wakeUpWebView?.releaseSleepDownWebView(clearResourceCache = false)
-        wakeUpWebView = null
-        val adapter = runCatching { ShiguangWarehouse.loadAdapters(context) }
-            .getOrDefault(emptyList())
-            .firstOrNull { it.isWakeUpImportTool() }
-        if (adapter == null) {
-            aiParsing = false
-            wakeUpImportInput = null
-            error = "未找到拾光 WakeUp 解析器"
-            return@LaunchedEffect
-        }
-        val source = runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
-            .getOrElse {
-                aiParsing = false
-                wakeUpImportInput = null
-                error = "拾光 WakeUp 解析器读取失败：${it.message ?: "未知错误"}"
-                return@LaunchedEffect
-            }
-        lateinit var target: WebView
-        val bridge = EduImportBridge(
-            context = context,
-            adapter = adapter,
-            baseConfig = { state.config },
-            basePeriods = { state.periods },
-            onDraft = { draft ->
-                error = null
-                routeMessage = "WakeUp 口令已解析，正在进入导入预览。"
-                wakeUpImportInput = null
-                aiParsing = false
-                onParsed(draft)
-            },
-            onMessage = { message ->
-                routeMessage = message
-                if (message.contains("失败") || message.contains("无效")) error = message
-            },
-            onTaskCompleted = {
-                if (wakeUpWebView === target) {
-                    target.releaseSleepDownWebView(clearResourceCache = false)
-                    wakeUpWebView = null
-                }
-                wakeUpImportInput = null
-                aiParsing = false
-            }
-        )
-        bridge.beginTask()
-        var scriptStarted = false
-        target = WebView(context).apply {
-            settings.javaScriptEnabled = true
-            settings.domStorageEnabled = false
-            settings.allowContentAccess = false
-            settings.allowFileAccess = false
-            attachEduImportBridge(bridge)
-            webViewClient = object : WebViewClient() {
-                override fun onPageFinished(view: WebView, url: String?) {
-                    super.onPageFinished(view, url)
-                    if (scriptStarted) return
-                    scriptStarted = true
-                    view.evaluateJavascript(EDU_BRIDGE_PROMISE_BOOTSTRAP) {
-                        view.evaluateJavascript(buildWakeUpInlineImportScript(source, input), null)
-                    }
-                }
-            }
-        }
-        wakeUpWebView = target
-        routeMessage = "正在使用拾光 WakeUp 解析器读取口令…"
-        target.loadDataWithBaseURL(
-            "https://api.wakeup.fun/",
-            "<!doctype html><html><head><meta charset=\"utf-8\"></head><body></body></html>",
-            "text/html",
-            "UTF-8",
-            null
-        )
-    }
-    LaunchedEffect(starLinkImportInput) {
-        val input = starLinkImportInput ?: return@LaunchedEffect
-        starLinkWebView?.releaseSleepDownWebView(clearResourceCache = false)
-        starLinkWebView = null
-        val adapter = runCatching { ShiguangWarehouse.loadAdapters(context) }
-            .getOrDefault(emptyList())
-            .firstOrNull { it.isStarLinkImportTool() }
-        if (adapter == null) {
-            aiParsing = false
-            starLinkImportInput = null
-            error = "未找到拾光星链解析器"
-            return@LaunchedEffect
-        }
-        val source = runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
-            .getOrElse {
-                aiParsing = false
-                starLinkImportInput = null
-                error = "拾光星链解析器读取失败：${it.message ?: "未知错误"}"
-                return@LaunchedEffect
-            }
-        lateinit var target: WebView
-        var fallbackToWakeUp = false
-        val bridge = EduImportBridge(
-            context = context,
-            adapter = adapter,
-            baseConfig = { state.config },
-            basePeriods = { state.periods },
-            onDraft = { draft ->
-                error = null
-                routeMessage = "星链口令已解析，正在进入导入预览。"
-                starLinkImportInput = null
-                aiParsing = false
-                onParsed(draft)
-            },
-            onMessage = { message ->
-                routeMessage = message
-                if (message.contains("失败") || message.contains("无效")) {
-                    fallbackToWakeUp = extractWakeUpShareKey(input) != null
-                    if (fallbackToWakeUp) {
-                        routeMessage = "星链未识别该分享码，正在自动尝试 WakeUp…"
-                    } else {
-                        error = message
-                    }
-                }
-            },
-            onTaskCompleted = {
-                if (starLinkWebView === target) {
-                    target.releaseSleepDownWebView(clearResourceCache = false)
-                    starLinkWebView = null
-                }
-                starLinkImportInput = null
-                if (fallbackToWakeUp) {
-                    error = null
-                    aiParsing = true
-                    wakeUpImportInput = input
-                } else {
-                    aiParsing = false
-                }
-            }
-        )
-        bridge.beginTask()
-        var scriptStarted = false
-        target = WebView(context).apply {
-            settings.javaScriptEnabled = true
-            settings.domStorageEnabled = false
-            settings.allowContentAccess = false
-            settings.allowFileAccess = false
-            attachEduImportBridge(bridge)
-            webViewClient = object : WebViewClient() {
-                override fun onPageFinished(view: WebView, url: String?) {
-                    super.onPageFinished(view, url)
-                    if (scriptStarted) return
-                    scriptStarted = true
-                    view.evaluateJavascript(EDU_BRIDGE_PROMISE_BOOTSTRAP) {
-                        view.evaluateJavascript(buildStarLinkInlineImportScript(source, input), null)
-                    }
-                }
-            }
-        }
-        starLinkWebView = target
-        routeMessage = "正在使用拾光星链解析器读取口令…"
-        target.loadDataWithBaseURL(
-            "https://api.starlinkkb.cn/",
-            "<!doctype html><html><head><meta charset=\"utf-8\"></head><body></body></html>",
-            "text/html",
-            "UTF-8",
-            null
-        )
     }
     val icsFileLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) launcher@{ uri ->
         if (uri == null) return@launcher
@@ -816,22 +534,6 @@ fun NormalizedAiManualImportScreen(
             error = null
             onParsed(it)
         }.onFailure {
-            val starLinkCode = extractStarLinkShareCode(jsonText)
-            if (starLinkCode != null) {
-                error = null
-                aiParsing = true
-                routeMessage = "正在使用拾光星链解析器读取口令…"
-                starLinkImportInput = jsonText
-                return@onFailure
-            }
-            val wakeUpKey = extractWakeUpShareKey(jsonText)
-            if (wakeUpKey != null) {
-                error = null
-                aiParsing = true
-                routeMessage = "正在使用拾光 WakeUp 解析器读取口令…"
-                wakeUpImportInput = jsonText
-                return@onFailure
-            }
             val latestSettings = AiImportSettingsStore.load(context)
             aiSettings = latestSettings
             if (latestSettings.apiKey.isNotBlank() && jsonText.isNotBlank()) {
@@ -1173,7 +875,7 @@ private fun AiManualImportDialogContent(
                     DialogCapsuleField(
                         value = jsonText,
                         onValueChange = onJsonTextChange,
-                        placeholder = "粘贴 SleepDown / WakeUp / 星链口令或 AI 返回内容",
+                        placeholder = "粘贴 SleepDown 口令或 AI 返回内容",
                         config = state.config,
                         minLines = 5,
                         cornerRadius = 16.dp,
@@ -1370,7 +1072,6 @@ fun EduSchoolPickerScreen(
     val adapters = remember(warehouseGeneration) {
         runCatching { ShiguangWarehouse.loadAdapters(context) }
             .getOrDefault(emptyList())
-            .filterNot { it.isWakeUpImportTool() || it.isStarLinkImportTool() }
     }
     var adapterChoices by remember { mutableStateOf<List<EduAdapter>?>(null) }
     var query by remember { mutableStateOf("") }
@@ -1566,9 +1267,7 @@ fun EduSchoolIndexedSelectScreen(
     val pinnedSchools = remember(schoolGroups) {
         schoolGroups.filter { group ->
             group !in aiEduSchools && group.adapters.any {
-                it.isGeneralEduTool() ||
-                        it.isEduTestTool() ||
-                        it.category.equals("GENERAL_TOOL", ignoreCase = true)
+                it.isGeneralEduTool()
             }
         }
             .sortedBy { it.school.id }
@@ -2399,11 +2098,10 @@ fun SchoolSearchField(
     }
 }
 
-private fun WebView.resolveEduBridgeInteraction(requestId: String, valueExpression: String) {
+private fun ShiguangBridgeHost.resolveEduBridgeInteraction(requestId: String, valueExpression: String) {
     evaluateJavascript(
-        "window.__sleepDownBridgeResolve && window.__sleepDownBridgeResolve(" +
-            JSONObject.quote(requestId) + ", " + valueExpression + ");",
-        null
+        "window._shiguangNativeCallback && window._shiguangNativeCallback(" +
+            JSONObject.quote(requestId) + ", true, " + valueExpression + ");"
     )
 }
 
@@ -2419,7 +2117,7 @@ private fun decodeEduBridgeValidationResult(encoded: String?): String? {
 }
 
 private fun validateEduBridgePrompt(
-    webView: WebView,
+    bridge: ShiguangBridgeHost,
     request: EduBridgeInteractionRequest.Prompt,
     value: String,
     onResult: (String?) -> Unit
@@ -2430,27 +2128,23 @@ private fun validateEduBridgePrompt(
         return
     }
     val script = """
-        (function (name, value) {
-            var validator = window[name];
-            if (typeof validator !== "function") {
-                return "输入校验函数不可用，请返回后重试";
-            }
+        (function () {
             try {
-                var result = validator(value);
+                var result = ${validator}(${JSONObject.quote(value)});
                 if (result === false || result == null || result === "") return null;
                 return String(result);
             } catch (error) {
                 return error && error.message ? error.message : String(error);
             }
-        })(${JSONObject.quote(validator)}, ${JSONObject.quote(value)});
+        })();
     """.trimIndent()
-    webView.evaluateJavascript(script) { onResult(decodeEduBridgeValidationResult(it)) }
+    bridge.evaluateJavascript(script) { onResult(decodeEduBridgeValidationResult(it)) }
 }
 
 @Composable
 private fun EduBridgeInteractionDialog(
     request: EduBridgeInteractionRequest?,
-    webView: WebView?,
+    bridge: ShiguangBridgeHost,
     state: AppState,
     backdrop: Backdrop?,
     onFinished: () -> Unit
@@ -2466,14 +2160,14 @@ private fun EduBridgeInteractionDialog(
                         label = request.confirmText,
                         style = LiquidAlertActionStyle.Primary
                     ) {
-                        webView?.resolveEduBridgeInteraction(request.requestId, "true")
+                        bridge.resolveEduBridgeInteraction(request.requestId, "true")
                         onFinished()
                     }
                 ),
                 backdrop = backdrop,
                 config = state.config,
                 onDismissRequest = {
-                    webView?.resolveEduBridgeInteraction(request.requestId, "false")
+                    bridge.resolveEduBridgeInteraction(request.requestId, "false")
                     onFinished()
                 }
             )
@@ -2482,19 +2176,14 @@ private fun EduBridgeInteractionDialog(
             var value by remember(request.requestId) { mutableStateOf(request.defaultValue) }
             var validationError by remember(request.requestId) { mutableStateOf<String?>(null) }
             fun cancel() {
-                webView?.resolveEduBridgeInteraction(request.requestId, "null")
+                bridge.resolveEduBridgeInteraction(request.requestId, "null")
                 onFinished()
             }
             fun submit() {
-                val target = webView
-                if (target == null) {
-                    validationError = "网页已关闭，请返回后重试"
-                    return
-                }
-                validateEduBridgePrompt(target, request, value) { error ->
+                validateEduBridgePrompt(bridge, request, value) { error ->
                     validationError = error
                     if (error == null) {
-                        target.resolveEduBridgeInteraction(request.requestId, JSONObject.quote(value))
+                        bridge.resolveEduBridgeInteraction(request.requestId, JSONObject.quote(value))
                         onFinished()
                     }
                 }
@@ -2550,12 +2239,12 @@ private fun EduBridgeInteractionDialog(
                 mutableIntStateOf(request.defaultIndex)
             }
             fun cancel() {
-                webView?.resolveEduBridgeInteraction(request.requestId, "null")
+                bridge.resolveEduBridgeInteraction(request.requestId, "null")
                 onFinished()
             }
             fun submit() {
                 if (selectedIndex !in request.options.indices) return
-                webView?.resolveEduBridgeInteraction(request.requestId, selectedIndex.toString())
+                bridge.resolveEduBridgeInteraction(request.requestId, selectedIndex.toString())
                 onFinished()
             }
             Dialog(
@@ -2643,28 +2332,21 @@ fun EduImportActivityScreen(
     var bridgeInteraction by remember { mutableStateOf<EduBridgeInteractionRequest?>(null) }
     var currentUrl by remember(adapter) {
         mutableStateOf(
-            if (adapter.requiresManualEduUrl()) "" else adapter.importUrl.ifBlank { "https://" }
+            if (adapter.requiresManualEduUrl()) "" else adapter.importUrl.ifBlank { "about:blank" }
         )
     }
     var showGeneralUrlDialog by remember(adapter) { mutableStateOf(adapter.requiresManualEduUrl()) }
-    val bridge = remember(state.config, adapter) {
-        EduImportBridge(
+    val bridge = remember(adapter) {
+        ShiguangBridgeHost(
             context = context,
-            adapter = adapter,
-            baseConfig = { state.config },
-            basePeriods = { state.periods },
             onDraft = onParsed,
             onMessage = { message = it },
-            onInteractionRequest = { bridgeInteraction = it },
-            onTaskCompleted = {
-                bridgeInteraction = null
-                webView?.detachEduImportBridge()
-            }
+            onInteractionRequest = { bridgeInteraction = it }
         )
     }
     EduBridgeInteractionDialog(
         request = bridgeInteraction,
-        webView = webView,
+        bridge = bridge,
         state = state,
         backdrop = backdrop,
         onFinished = { bridgeInteraction = null }
@@ -3034,7 +2716,7 @@ private fun eduDesktopUserAgent(context: Context): String {
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
-fun EduImportBrowserScreen(
+private fun EduImportBrowserScreen(
     state: AppState,
     adapter: EduAdapter,
     webContentBackdrop: LayerBackdrop,
@@ -3043,7 +2725,7 @@ fun EduImportBrowserScreen(
     onWebView: (WebView?) -> Unit,
     currentUrl: String,
     onUrlChange: (String) -> Unit,
-    bridge: EduImportBridge,
+    bridge: ShiguangBridgeHost,
     useDetailTopPadding: Boolean = true,
     onMessage: (String) -> Unit
 ) {
@@ -3061,9 +2743,7 @@ fun EduImportBrowserScreen(
     var popupWebView by remember(adapter) { mutableStateOf<WebView?>(null) }
     var webViewGeneration by remember(adapter) { mutableIntStateOf(0) }
     var rendererRestoreUrl by remember(adapter) { mutableStateOf<String?>(null) }
-    var pendingOriginalImportScript by remember(adapter) { mutableStateOf<String?>(null) }
-    var pendingImportGeneration by remember(adapter) { mutableIntStateOf(0) }
-    var importGeneration by remember(adapter) { mutableIntStateOf(0) }
+    val requestInterceptor = remember(adapter) { ShiguangWebRequestInterceptor() }
     val taskProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
     LaunchedEffect(taskProgress?.taskId, taskProgress?.finished) {
         val completed = taskProgress?.takeIf {
@@ -3330,21 +3010,6 @@ fun EduImportBrowserScreen(
         }
     }
 
-    fun executePendingOriginalImportScript(target: WebView) {
-        val script = pendingOriginalImportScript ?: return
-        pendingOriginalImportScript = null
-        onMessage("已安全启用导入桥接，正在执行拾光适配器")
-        target.evaluateJavascript(EDU_BRIDGE_PROMISE_BOOTSTRAP) {
-            target.evaluateJavascript(
-                """
-                console.log('SleepDown bridge check', !!window.AndroidBridgePromise, typeof window.AndroidBridgePromise?.showAlert, typeof window.AndroidBridge?.notifyTaskCompletion);
-                try { $script } catch (e) { console.error('SleepDown import script error', e && (e.stack || e.message || e)); throw e; }
-                """.trimIndent(),
-                null
-            )
-        }
-    }
-
     fun runOriginalImportScript() {
         val target = popupWebView ?: webView
         if (target == null) {
@@ -3359,25 +3024,11 @@ fun EduImportBrowserScreen(
         scope.launch {
             runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
                 .onSuccess { script ->
-                    importGeneration += 1
-                    pendingImportGeneration = importGeneration
-                    pendingOriginalImportScript = script
-                    bridge.beginTask()
-                    target.attachEduImportBridge(bridge)
-                    // addJavascriptInterface becomes visible to page JavaScript only after a navigation.
-                    // Reload the current page while the narrowly-scoped bridge is attached, run the
-                    // adapter from onPageFinished, then detach on completion or timeout.
-                    onMessage("已加载拾光仓库脚本，正在安全重载当前页面")
-                    target.reload()
-                    val generation = pendingImportGeneration
-                    launch {
-                        delay(15_000)
-                        if (importGeneration == generation && pendingOriginalImportScript != null) {
-                            pendingOriginalImportScript = null
-                            target.detachEduImportBridge()
-                            onMessage("当前页面重载超时，导入桥接已关闭，请检查网络后重试。")
-                        }
-                    }
+                    bridge.bindWebView(target)
+                    bridge.beginTask(state.config, state.periods)
+                    target.injectShiguangRuntime(desktopMode)
+                    onMessage("正在执行拾光官方适配器")
+                    target.evaluateJavascript(script, null)
                 }
                 .onFailure { onMessage("拾光仓库脚本加载失败：${it.message ?: "找不到该学校的导入脚本"}") }
         }
@@ -3405,11 +3056,13 @@ fun EduImportBrowserScreen(
 
     fun closePopupWebView() {
         popupWebView?.let { popup ->
+            popup.uninstallShiguangRuntime()
             (popup.parent as? ViewGroup)?.removeView(popup)
             popup.releaseSleepDownWebView(clearResourceCache = false)
         }
         popupWebView = null
         webView?.let { primary ->
+            bridge.bindWebView(primary)
             addressText = primary.url.orEmpty().ifBlank { currentUrl }
             onUrlChange(addressText)
             updateNavigationState(primary)
@@ -3458,7 +3111,7 @@ fun EduImportBrowserScreen(
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.databaseEnabled = true
-            configureEduImportSecurity(adapter)
+            configureEduImportSecurity()
             settings.useWideViewPort = true
             settings.loadWithOverviewMode = true
             settings.setSupportZoom(true)
@@ -3476,15 +3129,14 @@ fun EduImportBrowserScreen(
                 setAcceptCookie(true)
                 setAcceptThirdPartyCookies(this@webView, true)
             }
+            installShiguangRuntime(bridge)
             webViewClient = object : WebViewClient() {
                 override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest): Boolean {
                     return handleExternalNavigation(request.url)
                 }
 
                 override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
-                    if (pendingOriginalImportScript == null) {
-                        view?.detachEduImportBridge()
-                    }
+                    view?.injectShiguangRuntime(desktopMode)
                     val visiblePage = if (isPopup) popupWebView === view else popupWebView == null
                     if (visiblePage) updateNavigationState(view)
                     super.onPageStarted(view, url, favicon)
@@ -3492,6 +3144,7 @@ fun EduImportBrowserScreen(
 
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
+                    view?.injectShiguangRuntime(desktopMode)
                     view?.let { updateEduWebTopOffset(it) }
                     val visiblePage = if (isPopup) popupWebView === view else popupWebView == null
                     if (visiblePage) updateNavigationState(view)
@@ -3506,7 +3159,14 @@ fun EduImportBrowserScreen(
                         )
                         CookieManager.getInstance().flush()
                     }
-                    view?.let(::executePendingOriginalImportScript)
+                }
+
+                override fun shouldInterceptRequest(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): WebResourceResponse? {
+                    return request?.let { requestInterceptor.intercept(it, desktopMode) }
+                        ?: super.shouldInterceptRequest(view, request)
                 }
 
                 override fun onReceivedError(
@@ -3547,23 +3207,24 @@ fun EduImportBrowserScreen(
                     val restoreUrl = view?.url?.takeIf { it.isNotBlank() }
                         ?: addressText.takeIf { it.isNotBlank() }
                         ?: currentUrl
-                    view?.detachEduImportBridge()
+                    view?.uninstallShiguangRuntime()
                     (view?.parent as? ViewGroup)?.removeView(view)
                     view?.destroy()
                     popupWebView?.takeIf { it !== view }?.let { popup ->
-                        popup.detachEduImportBridge()
+                        popup.uninstallShiguangRuntime()
                         (popup.parent as? ViewGroup)?.removeView(popup)
                         popup.destroy()
                     }
                     popupWebView = null
                     if (isPopup) {
                         webView?.let { primary ->
-                            primary.detachEduImportBridge()
+                            primary.uninstallShiguangRuntime()
                             (primary.parent as? ViewGroup)?.removeView(primary)
                             primary.destroy()
                         }
                     }
                     onWebView(null)
+                    bridge.bindWebView(null)
                     rendererRestoreUrl = restoreUrl
                     webViewGeneration += 1
                     onMessage(
@@ -3604,6 +3265,7 @@ fun EduImportBrowserScreen(
         return WebView(context).apply {
             configureEduWebView(this, isPopup = false)
             onWebView(this)
+            bridge.bindWebView(this)
             updateNavigationState(this)
             val initialUrl = rendererRestoreUrl ?: normalizedUrl
             if (initialUrl.isNotBlank()) loadUrl(initialUrl)
@@ -3616,6 +3278,7 @@ fun EduImportBrowserScreen(
     DisposableEffect(Unit) {
         onDispose {
             popupWebView?.let { popup ->
+                popup.uninstallShiguangRuntime()
                 (popup.parent as? ViewGroup)?.removeView(popup)
                 popup.releaseSleepDownWebView(clearResourceCache = false)
             }
@@ -3645,7 +3308,11 @@ fun EduImportBrowserScreen(
                     // loadUrl from recomposition.
                     update = {},
                     onRelease = { released ->
-                        if (released === webView) onWebView(null)
+                        if (released === webView) {
+                            onWebView(null)
+                            bridge.bindWebView(null)
+                        }
+                        released.uninstallShiguangRuntime()
                         released.releaseSleepDownWebView()
                     }
                 )
@@ -3663,6 +3330,7 @@ fun EduImportBrowserScreen(
                         onRelease = { released ->
                             if (released === popupWebView) {
                                 popupWebView = null
+                                released.uninstallShiguangRuntime()
                                 released.releaseSleepDownWebView(clearResourceCache = false)
                             }
                         }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -31,6 +31,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas as AndroidCanvas
 import android.net.Uri
 import android.net.http.SslError
 import android.provider.MediaStore
@@ -1244,6 +1245,7 @@ fun EduSchoolPickerScreen(
     val adapters = remember(warehouseGeneration) {
         runCatching { ShiguangWarehouse.loadAdapters(context) }
             .getOrDefault(emptyList())
+            .filterNot(EduAdapter::isGeneralEduTool)
     }
     var adapterChoices by remember { mutableStateOf<List<EduAdapter>?>(null) }
     var query by remember { mutableStateOf("") }
@@ -2917,6 +2919,9 @@ private fun EduImportBrowserScreen(
     var popupWebView by remember(adapter) { mutableStateOf<WebView?>(null) }
     var webViewGeneration by remember(adapter) { mutableIntStateOf(0) }
     var rendererRestoreUrl by remember(adapter) { mutableStateOf<String?>(null) }
+    var webTopEdgeBitmap by remember(adapter) { mutableStateOf<Bitmap?>(null) }
+    val topEdgeSampleHandler = remember(adapter) { Handler(Looper.getMainLooper()) }
+    val topEdgeSampleToken = remember(adapter) { Any() }
     val requestInterceptor = remember(adapter) { ShiguangWebRequestInterceptor() }
     val taskProgress by AiEduImportProgressSession.progress.collectAsStateWithLifecycle()
     LaunchedEffect(taskProgress?.taskId, taskProgress?.finished) {
@@ -2928,9 +2933,25 @@ private fun EduImportBrowserScreen(
         onMessage(completed.error ?: completed.liveSummary.ifBlank { completed.steps.lastOrNull().orEmpty() })
     }
     val topPadding = if (useDetailTopPadding) detailContentTopPadding() else 0.dp
-    val webContentTopInsetPx = with(LocalDensity.current) { topPadding.roundToPx() }
     val normalizedUrl = remember(addressText) {
         normalizeEduUrl(addressText)
+    }
+
+    fun scheduleWebTopEdgeSample(target: WebView) {
+        topEdgeSampleHandler.removeCallbacksAndMessages(topEdgeSampleToken)
+        topEdgeSampleHandler.postAtTime(
+            {
+                val width = target.width
+                if (width > 0 && target.height > 0) {
+                    Bitmap.createBitmap(width, 1, Bitmap.Config.ARGB_8888).also { bitmap ->
+                        target.draw(AndroidCanvas(bitmap))
+                        webTopEdgeBitmap = bitmap
+                    }
+                }
+            },
+            topEdgeSampleToken,
+            android.os.SystemClock.uptimeMillis() + 48L
+        )
     }
 
     fun loadAddress() {
@@ -3240,6 +3261,7 @@ private fun EduImportBrowserScreen(
             addressText = primary.url.orEmpty().ifBlank { currentUrl }
             onUrlChange(addressText)
             updateNavigationState(primary)
+            scheduleWebTopEdgeSample(primary)
         }
     }
 
@@ -3265,22 +3287,11 @@ private fun EduImportBrowserScreen(
         return true
     }
 
-    fun updateEduWebTopOffset(target: WebView, scrollY: Int = target.scrollY) {
-        if (webContentTopInsetPx <= 0) {
-            target.translationY = 0f
-            return
-        }
-        val collapseDistance = webContentTopInsetPx * 2.5f
-        val collapseProgress = (scrollY.coerceAtLeast(0) / collapseDistance).coerceIn(0f, 1f)
-        target.translationY = webContentTopInsetPx * (1f - collapseProgress)
-    }
-
     fun configureEduWebView(target: WebView, isPopup: Boolean) {
         target.apply webView@ {
             setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null)
-            updateEduWebTopOffset(this)
-            setOnScrollChangeListener { _, _, scrollY, _, _ ->
-                updateEduWebTopOffset(this, scrollY)
+            setOnScrollChangeListener { _, _, _, _, _ ->
+                scheduleWebTopEdgeSample(this)
             }
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
@@ -3319,7 +3330,7 @@ private fun EduImportBrowserScreen(
                 override fun onPageFinished(view: WebView?, url: String?) {
                     super.onPageFinished(view, url)
                     view?.injectShiguangRuntime(desktopMode)
-                    view?.let { updateEduWebTopOffset(it) }
+                    view?.let(::scheduleWebTopEdgeSample)
                     val visiblePage = if (isPopup) popupWebView === view else popupWebView == null
                     if (visiblePage) updateNavigationState(view)
                     if (visiblePage && !url.isNullOrBlank()) {
@@ -3451,6 +3462,7 @@ private fun EduImportBrowserScreen(
     }
     DisposableEffect(Unit) {
         onDispose {
+            topEdgeSampleHandler.removeCallbacksAndMessages(topEdgeSampleToken)
             popupWebView?.let { popup ->
                 popup.uninstallShiguangRuntime()
                 (popup.parent as? ViewGroup)?.removeView(popup)
@@ -3460,9 +3472,9 @@ private fun EduImportBrowserScreen(
         }
     }
 
-    // The producer and unclipped WebView span the whole window. The complete WebView surface starts
-    // below the compact bar, then its translation collapses from real scrollY so fixed page headers
-    // remain intact and can move beneath the gradient glass. Dock and popups stay outside capture.
+    // Keep the WebView at its natural position below the compact bar. A one-pixel sample of the
+    // current WebView top edge is stretched only through the producer's top-bar region, so the
+    // gradient glass keeps the page color without moving or clipping the page header itself.
     Box(modifier = Modifier.fillMaxSize()) {
         Box(
             modifier = Modifier
@@ -3470,10 +3482,21 @@ private fun EduImportBrowserScreen(
                 .glassBackdropProducer(webContentBackdrop)
                 .background(MaterialTheme.colorScheme.background)
         ) {
+            webTopEdgeBitmap?.let { edge ->
+                Image(
+                    bitmap = edge.asImageBitmap(),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(topPadding),
+                    contentScale = ContentScale.FillBounds
+                )
+            }
             key(webViewGeneration) {
                 AndroidView(
                     modifier = Modifier
                         .fillMaxSize()
+                        .padding(top = topPadding)
                         .graphicsLayer {
                             compositingStrategy = CompositingStrategy.Offscreen
                         },
@@ -3496,6 +3519,7 @@ private fun EduImportBrowserScreen(
                     AndroidView(
                         modifier = Modifier
                             .fillMaxSize()
+                            .padding(top = topPadding)
                             .graphicsLayer {
                                 compositingStrategy = CompositingStrategy.Offscreen
                             },

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -3242,11 +3242,14 @@ private fun EduImportBrowserScreen(
                 null
             }
             useWideViewPort = true
-            loadWithOverviewMode = !desktop
+            // Keep Chromium's overview layout in both modes. Desktop identity still comes from the
+            // current system WebView UA, while the initial page is allowed to fit the real host
+            // width instead of exposing only the upper-left part of fixed-width teaching sites.
+            loadWithOverviewMode = true
             layoutAlgorithm = WebSettings.LayoutAlgorithm.NORMAL
             textZoom = 100
         }
-        target.setInitialScale(if (desktop) 100 else 0)
+        target.setInitialScale(0)
     }
 
     fun closePopupWebView() {
@@ -3289,6 +3292,11 @@ private fun EduImportBrowserScreen(
 
     fun configureEduWebView(target: WebView, isPopup: Boolean) {
         target.apply webView@ {
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+            )
+            setBackgroundColor(android.graphics.Color.TRANSPARENT)
             setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null)
             setOnScrollChangeListener { _, _, _, _, _ ->
                 scheduleWebTopEdgeSample(this)

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/ImportUi.kt
@@ -348,6 +348,40 @@ data class AiImportHistoryBackgroundCapture(
     val rootTopInWindow: Float
 )
 
+private val WakeUpLabelledKey = Regex(
+    "分享口令(?:为)?\\s*[「“\\\"]?\\s*([A-Za-z0-9_-]{8,200})\\s*[」”\\\"]?",
+    setOf(RegexOption.IGNORE_CASE)
+)
+private val WakeUpBareKey = Regex("^[A-Za-z0-9_-]{8,200}$")
+private val StarLinkStructuredCode = Regex(
+    "(?:星链|StarLink|输入[:：])[^A-Za-z0-9-]*([A-Za-z0-9-]{5,20})",
+    setOf(RegexOption.IGNORE_CASE)
+)
+private val StarLinkBareCode = Regex("^[A-Za-z0-9-]{5,20}$")
+
+private data class ManualShiguangToolRequest(
+    val adapterId: String,
+    val label: String,
+    val input: String
+)
+
+private fun extractWakeUpShareKey(value: String): String? {
+    val text = value.trim()
+    if (text.isBlank()) return null
+    WakeUpLabelledKey.find(text)?.groupValues?.getOrNull(1)?.let { return it }
+    if (text.contains("wakeup", ignoreCase = true)) {
+        Regex("[A-Za-z0-9_-]{8,200}").findAll(text).lastOrNull()?.value?.let { return it }
+    }
+    return text.takeIf(WakeUpBareKey::matches)
+}
+
+private fun extractStarLinkShareCode(value: String): String? {
+    val text = value.trim()
+    if (text.isBlank()) return null
+    return StarLinkStructuredCode.find(text)?.groupValues?.getOrNull(1)
+        ?: text.takeIf(StarLinkBareCode::matches)
+}
+
 @Composable
 fun NormalizedAiManualImportScreen(
     state: AppState,
@@ -366,6 +400,10 @@ fun NormalizedAiManualImportScreen(
     var routeMessage by remember { mutableStateOf<String?>(null) }
     var selectedFileName by remember { mutableStateOf<String?>(null) }
     var aiParsing by remember { mutableStateOf(false) }
+    var manualToolRequest by remember { mutableStateOf<ManualShiguangToolRequest?>(null) }
+    var manualToolWebView by remember { mutableStateOf<WebView?>(null) }
+    var manualToolBridge by remember { mutableStateOf<ShiguangBridgeHost?>(null) }
+    var manualBridgeInteraction by remember { mutableStateOf<EduBridgeInteractionRequest?>(null) }
     var showAiTokenRepairPrompt by remember { mutableStateOf(false) }
     var selectedMode by remember { mutableIntStateOf(0) }
     var aiSettings by remember { mutableStateOf(AiImportSettingsStore.load(context)) }
@@ -387,6 +425,99 @@ fun NormalizedAiManualImportScreen(
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+    fun releaseManualToolWebView() {
+        manualToolBridge?.bindWebView(null)
+        manualToolWebView?.let { released ->
+            released.uninstallShiguangRuntime()
+            released.releaseSleepDownWebView(clearResourceCache = false)
+        }
+        manualToolWebView = null
+        manualToolBridge = null
+        manualBridgeInteraction = null
+    }
+    DisposableEffect(Unit) {
+        onDispose {
+            manualToolBridge?.bindWebView(null)
+            manualToolWebView?.let { released ->
+                released.uninstallShiguangRuntime()
+                released.releaseSleepDownWebView(clearResourceCache = false)
+            }
+        }
+    }
+    LaunchedEffect(manualToolRequest) {
+        val request = manualToolRequest ?: return@LaunchedEffect
+        releaseManualToolWebView()
+        val adapter = ShiguangWarehouse.loadAdapters(context).firstOrNull {
+            it.school.id == "GLOBAL_TOOLS" && it.adapterId.equals(request.adapterId, ignoreCase = true)
+        }
+        if (adapter == null) {
+            aiParsing = false
+            manualToolRequest = null
+            error = "未找到拾光 ${request.label} 官方适配器"
+            return@LaunchedEffect
+        }
+        val source = runCatching { ShiguangWarehouse.resolveScript(context, adapter) }
+            .getOrElse {
+                aiParsing = false
+                manualToolRequest = null
+                error = "拾光 ${request.label} 官方脚本读取失败：${it.message ?: "未知错误"}"
+                return@LaunchedEffect
+            }
+        lateinit var target: WebView
+        val bridge = ShiguangBridgeHost(
+            context = context,
+            onDraft = { draft ->
+                if (manualToolWebView === target) releaseManualToolWebView()
+                manualToolRequest = null
+                aiParsing = false
+                error = null
+                routeMessage = "${request.label} 口令已解析，正在进入导入预览。"
+                onParsed(draft)
+            },
+            onMessage = { message ->
+                routeMessage = message
+                if (message.contains("失败") || message.contains("无效")) {
+                    error = message
+                    aiParsing = false
+                    manualToolRequest = null
+                    if (manualToolWebView === target) releaseManualToolWebView()
+                }
+            },
+            onInteractionRequest = { manualBridgeInteraction = it }
+        )
+        manualToolBridge = bridge
+        bridge.beginTask(state.config, state.periods, initialPromptAnswer = request.input)
+        var scriptStarted = false
+        target = WebView(context).apply {
+            settings.javaScriptEnabled = true
+            settings.domStorageEnabled = true
+            settings.cacheMode = WebSettings.LOAD_DEFAULT
+            configureEduImportSecurity()
+            CookieManager.getInstance().setAcceptCookie(true)
+            CookieManager.getInstance().setAcceptThirdPartyCookies(this, true)
+            setLayerType(android.view.View.LAYER_TYPE_HARDWARE, null)
+            installShiguangRuntime(bridge)
+            bridge.bindWebView(this)
+            webViewClient = object : WebViewClient() {
+                override fun onPageStarted(view: WebView, url: String?, favicon: Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    view.injectShiguangRuntime(desktopMode = false)
+                }
+
+                override fun onPageFinished(view: WebView, url: String?) {
+                    super.onPageFinished(view, url)
+                    view.injectShiguangRuntime(desktopMode = false)
+                    if (!scriptStarted) {
+                        scriptStarted = true
+                        view.evaluateJavascript(source, null)
+                    }
+                }
+            }
+        }
+        manualToolWebView = target
+        routeMessage = "正在使用拾光 ${request.label} 官方适配器读取口令…"
+        target.loadUrl(adapter.importUrl.ifBlank { "about:blank" })
     }
     val icsFileLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) launcher@{ uri ->
         if (uri == null) return@launcher
@@ -534,6 +665,28 @@ fun NormalizedAiManualImportScreen(
             error = null
             onParsed(it)
         }.onFailure {
+            val starLinkCode = extractStarLinkShareCode(jsonText)
+            if (starLinkCode != null) {
+                error = null
+                aiParsing = true
+                manualToolRequest = ManualShiguangToolRequest(
+                    adapterId = "StarLink",
+                    label = "星链",
+                    input = jsonText
+                )
+                return@onFailure
+            }
+            val wakeUpKey = extractWakeUpShareKey(jsonText)
+            if (wakeUpKey != null) {
+                error = null
+                aiParsing = true
+                manualToolRequest = ManualShiguangToolRequest(
+                    adapterId = "WakeUp",
+                    label = "WakeUp",
+                    input = jsonText
+                )
+                return@onFailure
+            }
             val latestSettings = AiImportSettingsStore.load(context)
             aiSettings = latestSettings
             if (latestSettings.apiKey.isNotBlank() && jsonText.isNotBlank()) {
@@ -712,6 +865,25 @@ fun NormalizedAiManualImportScreen(
             }
         }
     )
+    manualToolBridge?.let { bridge ->
+        EduBridgeInteractionDialog(
+            request = manualBridgeInteraction,
+            bridge = bridge,
+            state = state,
+            backdrop = backdrop,
+            onFinished = {
+                val completed = manualBridgeInteraction
+                manualBridgeInteraction = null
+                if (completed is EduBridgeInteractionRequest.Alert &&
+                    completed.title.contains("失败")) {
+                    error = completed.message
+                    aiParsing = false
+                    manualToolRequest = null
+                    releaseManualToolWebView()
+                }
+            }
+        )
+    }
     if (showAiTokenRepairPrompt) {
         LiquidAlertDialog(
             title = "口令格式不完整",
@@ -875,7 +1047,7 @@ private fun AiManualImportDialogContent(
                     DialogCapsuleField(
                         value = jsonText,
                         onValueChange = onJsonTextChange,
-                        placeholder = "粘贴 SleepDown 口令或 AI 返回内容",
+                        placeholder = "粘贴 SleepDown / WakeUp / 星链口令或 AI 返回内容",
                         config = state.config,
                         minLines = 5,
                         cornerRadius = 16.dp,
@@ -2138,7 +2310,9 @@ private fun validateEduBridgePrompt(
             }
         })();
     """.trimIndent()
-    bridge.evaluateJavascript(script) { onResult(decodeEduBridgeValidationResult(it)) }
+    if (!bridge.evaluateJavascript(script) { onResult(decodeEduBridgeValidationResult(it)) }) {
+        onResult("网页已关闭，请返回后重试")
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangBridgeHost.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangBridgeHost.kt
@@ -1,0 +1,157 @@
+package com.xiaomanjun.sleepdownschedule.feature.importing.shiguang
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.webkit.JavascriptInterface
+import android.webkit.ValueCallback
+import android.webkit.WebView
+import android.widget.Toast
+import com.xiaomanjun.sleepdownschedule.ImportDraft
+import com.xiaomanjun.sleepdownschedule.PeriodEntity
+import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
+import com.xiaomanjun.sleepdownschedule.feature.importing.EduBridgeInteractionRequest
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.decodeFromString
+
+internal class ShiguangBridgeHost(
+    private val context: Context,
+    private val onDraft: (ImportDraft) -> Unit,
+    private val onMessage: (String) -> Unit,
+    private val onInteractionRequest: (EduBridgeInteractionRequest) -> Unit
+) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val session = ShiguangImportSession()
+    private var activeWebView: WebView? = null
+
+    fun bindWebView(webView: WebView?) {
+        activeWebView = webView
+    }
+
+    fun evaluateJavascript(script: String, callback: ValueCallback<String?>? = null) {
+        activeWebView?.evaluateJavascript(script, callback)
+    }
+
+    fun beginTask(config: ScheduleConfigEntity, periods: List<PeriodEntity>) {
+        session.begin(config, periods)
+    }
+
+    fun onMessageReceived(jsonString: String) {
+        val message = try {
+            ShiguangBridgeJson.decodeFromString(ShiguangBridgeMessage.serializer(), jsonString)
+        } catch (error: Exception) {
+            mainHandler.post { onMessage("拾光 Bridge 消息无效：${error.message}") }
+            return
+        }
+        try {
+            when (message.action) {
+                "showToast" -> parsePayload<ShiguangShowToastPayload>(message).let { payload ->
+                    mainHandler.post {
+                        Toast.makeText(context, payload.message, Toast.LENGTH_SHORT).show()
+                        onMessage(payload.message)
+                    }
+                }
+
+                "showAlert" -> parsePayload<ShiguangShowAlertPayload>(message).let { payload ->
+                    val callbackId = requireCallbackId(message)
+                    mainHandler.post {
+                        onInteractionRequest(
+                            EduBridgeInteractionRequest.Alert(
+                                requestId = callbackId,
+                                title = payload.titleText.ifBlank { "提示" },
+                                message = payload.contentText,
+                                confirmText = payload.confirmText.orEmpty().ifBlank { "确定" }
+                            )
+                        )
+                    }
+                }
+
+                "showPrompt" -> parsePayload<ShiguangShowPromptPayload>(message).let { payload ->
+                    val callbackId = requireCallbackId(message)
+                    mainHandler.post {
+                        onInteractionRequest(
+                            EduBridgeInteractionRequest.Prompt(
+                                requestId = callbackId,
+                                title = payload.titleText.ifBlank { "请输入" },
+                                message = payload.tipText,
+                                defaultValue = payload.defaultText,
+                                validator = payload.validatorJsFunction?.takeIf(String::isNotBlank)
+                            )
+                        )
+                    }
+                }
+
+                "showSingleSelection" -> parsePayload<ShiguangShowSingleSelectionPayload>(message).let { payload ->
+                    val callbackId = requireCallbackId(message)
+                    val options = ShiguangPayloadJson.decodeFromString(
+                        ListSerializer(String.serializer()),
+                        payload.itemsJsonString
+                    )
+                    mainHandler.post {
+                        onInteractionRequest(
+                            EduBridgeInteractionRequest.SingleSelection(
+                                requestId = callbackId,
+                                title = payload.titleText.ifBlank { "请选择" },
+                                options = options,
+                                defaultIndex = payload.defaultSelectedIndex.takeIf { it in options.indices } ?: -1
+                            )
+                        )
+                    }
+                }
+
+                "saveImportedCourses" -> parsePayload<ShiguangSaveCoursesPayload>(message).let { payload ->
+                    session.stageCourses(payload.coursesJsonString)
+                    resolve(requireCallbackId(message), "true")
+                }
+
+                "saveCourseConfig" -> parsePayload<ShiguangSaveConfigPayload>(message).let { payload ->
+                    session.stageCourseConfig(payload.configJsonString)
+                    resolve(requireCallbackId(message), "true")
+                }
+
+                "savePresetTimeSlots" -> parsePayload<ShiguangSaveTimeSlotsPayload>(message).let { payload ->
+                    session.stageTimeSlots(payload.timeSlotsJsonString)
+                    resolve(requireCallbackId(message), "true")
+                }
+
+                "notifyTaskCompletion" -> {
+                    val draft = session.complete()
+                    mainHandler.post { onDraft(draft) }
+                }
+
+                else -> throw IllegalArgumentException("未知拾光 Bridge action：${message.action}")
+            }
+        } catch (error: Exception) {
+            val detail = error.message ?: "拾光 Bridge 处理失败"
+            message.callbackId?.let { reject(it, detail) }
+                ?: mainHandler.post { onMessage(detail) }
+        }
+    }
+
+    private inline fun <reified T> parsePayload(message: ShiguangBridgeMessage): T {
+        val payload = requireNotNull(message.payload) { "${message.action} 缺少 payload" }
+        return ShiguangBridgeJson.decodeFromString(payload)
+    }
+
+    private fun requireCallbackId(message: ShiguangBridgeMessage): String =
+        requireNotNull(message.callbackId) { "${message.action} 缺少 callbackId" }
+
+    private fun resolve(callbackId: String, resultRawJs: String) {
+        val script = buildShiguangJsCallbackScript(callbackId, success = true, resultRawJs)
+        mainHandler.post { evaluateJavascript(script) }
+    }
+
+    private fun reject(callbackId: String, errorText: String) {
+        val errorJson = ShiguangBridgeJson.encodeToString(String.serializer(), errorText)
+        val script = buildShiguangJsCallbackScript(callbackId, success = false, errorJson)
+        mainHandler.post { evaluateJavascript(script) }
+    }
+}
+
+internal class ShiguangNativeBridge(private val host: ShiguangBridgeHost) {
+    @JavascriptInterface
+    fun postMessage(jsonMessage: String) {
+        host.onMessageReceived(jsonMessage)
+    }
+}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangBridgeHost.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangBridgeHost.kt
@@ -24,17 +24,25 @@ internal class ShiguangBridgeHost(
     private val mainHandler = Handler(Looper.getMainLooper())
     private val session = ShiguangImportSession()
     private var activeWebView: WebView? = null
+    private var initialPromptAnswer: String? = null
 
     fun bindWebView(webView: WebView?) {
         activeWebView = webView
     }
 
-    fun evaluateJavascript(script: String, callback: ValueCallback<String?>? = null) {
-        activeWebView?.evaluateJavascript(script, callback)
+    fun evaluateJavascript(script: String, callback: ValueCallback<String?>? = null): Boolean {
+        val target = activeWebView ?: return false
+        target.evaluateJavascript(script, callback)
+        return true
     }
 
-    fun beginTask(config: ScheduleConfigEntity, periods: List<PeriodEntity>) {
+    fun beginTask(
+        config: ScheduleConfigEntity,
+        periods: List<PeriodEntity>,
+        initialPromptAnswer: String? = null
+    ) {
         session.begin(config, periods)
+        this.initialPromptAnswer = initialPromptAnswer
     }
 
     fun onMessageReceived(jsonString: String) {
@@ -69,6 +77,14 @@ internal class ShiguangBridgeHost(
 
                 "showPrompt" -> parsePayload<ShiguangShowPromptPayload>(message).let { payload ->
                     val callbackId = requireCallbackId(message)
+                    initialPromptAnswer?.let { answer ->
+                        initialPromptAnswer = null
+                        resolve(
+                            callbackId,
+                            ShiguangBridgeJson.encodeToString(String.serializer(), answer)
+                        )
+                        return@let
+                    }
                     mainHandler.post {
                         onInteractionRequest(
                             EduBridgeInteractionRequest.Prompt(

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangBridgeProtocol.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangBridgeProtocol.kt
@@ -1,0 +1,179 @@
+package com.xiaomanjun.sleepdownschedule.feature.importing.shiguang
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+internal val ShiguangBridgeJson = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+}
+
+internal val ShiguangPayloadJson = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    coerceInputValues = true
+}
+
+@Serializable
+internal data class ShiguangBridgeMessage(
+    @SerialName("action") val action: String,
+    @SerialName("callbackId") val callbackId: String? = null,
+    @SerialName("payload") val payload: String? = null
+)
+
+@Serializable
+internal data class ShiguangShowToastPayload(val message: String)
+
+@Serializable
+internal data class ShiguangShowAlertPayload(
+    val titleText: String,
+    val contentText: String,
+    val confirmText: String? = null
+)
+
+@Serializable
+internal data class ShiguangShowPromptPayload(
+    val titleText: String,
+    val tipText: String,
+    val defaultText: String = "",
+    val validatorJsFunction: String? = null
+)
+
+@Serializable
+internal data class ShiguangShowSingleSelectionPayload(
+    val titleText: String,
+    val itemsJsonString: String,
+    val defaultSelectedIndex: Int = -1
+)
+
+@Serializable
+internal data class ShiguangSaveCoursesPayload(val coursesJsonString: String)
+
+@Serializable
+internal data class ShiguangSaveConfigPayload(val configJsonString: String)
+
+@Serializable
+internal data class ShiguangSaveTimeSlotsPayload(val timeSlotsJsonString: String)
+
+internal fun buildShiguangJsCallbackScript(
+    callbackId: String,
+    success: Boolean,
+    resultRawJs: String
+): String = "window._shiguangNativeCallback('$callbackId', $success, $resultRawJs);"
+
+internal val ShiguangBridgeInitScript = """
+(function() {
+    if (window._shiguangBridgeInjected) return;
+    window._shiguangBridgeInjected = true;
+
+    var callbacks = {};
+    var callbackCounter = 0;
+
+    function postRawMessage(msg) {
+        if (window._shiguangNativeBridge && typeof window._shiguangNativeBridge.postMessage === 'function') {
+            window._shiguangNativeBridge.postMessage(msg);
+            return;
+        }
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.shiguangBridge) {
+            window.webkit.messageHandlers.shiguangBridge.postMessage(msg);
+            return;
+        }
+        if (typeof window.cefQuery === 'function') {
+            window.cefQuery({ request: msg });
+            return;
+        }
+        console.warn("[ShiguangBridge] Native bridge unavailable:", msg);
+    }
+
+    function postMessageToNative(action, payload, callbackId) {
+        var msg = JSON.stringify({
+            action: action,
+            callbackId: callbackId || null,
+            payload: payload ? JSON.stringify(payload) : null
+        });
+        postRawMessage(msg);
+    }
+
+    window._shiguangNativeCallback = function(callbackId, isSuccess, result) {
+        var cb = callbacks[callbackId];
+        if (cb) {
+            if (isSuccess) cb.resolve(result); else cb.reject(result);
+            delete callbacks[callbackId];
+        }
+    };
+
+    var shiguangBridgePromise = {
+        showAlert: function(titleText, contentText, confirmText) {
+            return new Promise(function(resolve, reject) {
+                var id = 'cb_' + (++callbackCounter) + '_' + Date.now();
+                callbacks[id] = { resolve: resolve, reject: reject };
+                postMessageToNative('showAlert', {
+                    titleText: titleText || '',
+                    contentText: contentText || '',
+                    confirmText: confirmText || null
+                }, id);
+            });
+        },
+        showPrompt: function(titleText, tipText, defaultText, validatorJsFunction) {
+            return new Promise(function(resolve, reject) {
+                var id = 'cb_' + (++callbackCounter) + '_' + Date.now();
+                callbacks[id] = { resolve: resolve, reject: reject };
+                postMessageToNative('showPrompt', {
+                    titleText: titleText || '',
+                    tipText: tipText || '',
+                    defaultText: defaultText || '',
+                    validatorJsFunction: validatorJsFunction || ''
+                }, id);
+            });
+        },
+        showSingleSelection: function(titleText, items, defaultSelectedIndex) {
+            return new Promise(function(resolve, reject) {
+                var id = 'cb_' + (++callbackCounter) + '_' + Date.now();
+                callbacks[id] = { resolve: resolve, reject: reject };
+                var itemsJson = (typeof items === 'string') ? items : JSON.stringify(items || []);
+                postMessageToNative('showSingleSelection', {
+                    titleText: titleText || '',
+                    itemsJsonString: itemsJson,
+                    defaultSelectedIndex: defaultSelectedIndex !== undefined ? defaultSelectedIndex : -1
+                }, id);
+            });
+        },
+        saveImportedCourses: function(coursesJsonString) {
+            return new Promise(function(resolve, reject) {
+                var id = 'cb_' + (++callbackCounter) + '_' + Date.now();
+                callbacks[id] = { resolve: resolve, reject: reject };
+                postMessageToNative('saveImportedCourses', { coursesJsonString: coursesJsonString }, id);
+            });
+        },
+        saveCourseConfig: function(configJsonString) {
+            return new Promise(function(resolve, reject) {
+                var id = 'cb_' + (++callbackCounter) + '_' + Date.now();
+                callbacks[id] = { resolve: resolve, reject: reject };
+                postMessageToNative('saveCourseConfig', { configJsonString: configJsonString }, id);
+            });
+        },
+        savePresetTimeSlots: function(timeSlotsJsonString) {
+            return new Promise(function(resolve, reject) {
+                var id = 'cb_' + (++callbackCounter) + '_' + Date.now();
+                callbacks[id] = { resolve: resolve, reject: reject };
+                postMessageToNative('savePresetTimeSlots', { timeSlotsJsonString: timeSlotsJsonString }, id);
+            });
+        }
+    };
+
+    var shiguangBridge = {
+        showToast: function(message) {
+            postMessageToNative('showToast', { message: message });
+        },
+        notifyTaskCompletion: function() {
+            postMessageToNative('notifyTaskCompletion');
+        }
+    };
+
+    window.shiguangBridgePromise = shiguangBridgePromise;
+    window.shiguangBridge = shiguangBridge;
+    window.AndroidBridgePromise = shiguangBridgePromise;
+    window.AndroidBridge = shiguangBridge;
+})();
+""".trimIndent()

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangImportSession.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangImportSession.kt
@@ -1,0 +1,233 @@
+package com.xiaomanjun.sleepdownschedule.feature.importing.shiguang
+
+import com.xiaomanjun.sleepdownschedule.ImportDraft
+import com.xiaomanjun.sleepdownschedule.PeriodEntity
+import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
+import com.xiaomanjun.sleepdownschedule.CourseEntity
+import com.xiaomanjun.sleepdownschedule.WeekParity
+import com.xiaomanjun.sleepdownschedule.courseAnchorPeriodsForTimeRange
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import java.time.LocalTime
+
+@Serializable
+internal data class ShiguangCoursePayload(
+    val id: String? = null,
+    val name: String,
+    val teacher: String,
+    val position: String,
+    val day: Int,
+    val startSection: Int? = null,
+    val endSection: Int? = null,
+    val weeks: List<Int>,
+    val isCustomTime: Boolean = false,
+    val customStartTime: String? = null,
+    val customEndTime: String? = null,
+    val color: Int? = null,
+    val remark: String? = null
+)
+
+@Serializable
+internal data class ShiguangCourseConfigPayload(
+    val semesterStartDate: String? = null,
+    val semesterTotalWeeks: Int = 20,
+    val defaultClassDuration: Int = 45,
+    val defaultBreakDuration: Int = 10,
+    val firstDayOfWeek: Int = 1
+)
+
+@Serializable
+internal data class ShiguangTimeSlotPayload(
+    val number: Int,
+    val startTime: String,
+    val endTime: String,
+    val alias: String? = null
+)
+
+internal class ShiguangImportSession {
+    private val lock = Any()
+    private var active = false
+    private var baseConfig: ScheduleConfigEntity? = null
+    private var basePeriods: List<PeriodEntity> = emptyList()
+    private var courses: List<ShiguangCoursePayload>? = null
+    private var courseConfig: ShiguangCourseConfigPayload? = null
+    private var timeSlots: List<ShiguangTimeSlotPayload>? = null
+
+    fun begin(config: ScheduleConfigEntity, periods: List<PeriodEntity>) {
+        synchronized(lock) {
+            active = true
+            baseConfig = config
+            basePeriods = periods
+            courses = null
+            courseConfig = null
+            timeSlots = null
+        }
+    }
+
+    fun stageCourses(json: String) {
+        val parsed = ShiguangPayloadJson.decodeFromString(
+            ListSerializer(ShiguangCoursePayload.serializer()),
+            json
+        )
+        require(parsed.isNotEmpty()) { "课程数据为空" }
+        parsed.forEachIndexed { index, course -> validateCourse(index, course) }
+        synchronized(lock) {
+            require(active) { "当前没有正在执行的拾光导入任务" }
+            courses = parsed
+        }
+    }
+
+    fun stageCourseConfig(json: String) {
+        val parsed = ShiguangPayloadJson.decodeFromString(ShiguangCourseConfigPayload.serializer(), json)
+        require(parsed.semesterTotalWeeks in 1..60) { "semesterTotalWeeks 必须在 1 到 60 之间" }
+        require(parsed.defaultClassDuration in 1..300) { "defaultClassDuration 无效" }
+        require(parsed.defaultBreakDuration in 0..300) { "defaultBreakDuration 无效" }
+        require(parsed.firstDayOfWeek in 1..7) { "firstDayOfWeek 必须在 1 到 7 之间" }
+        parsed.semesterStartDate?.let { java.time.LocalDate.parse(it) }
+        synchronized(lock) {
+            require(active) { "当前没有正在执行的拾光导入任务" }
+            courseConfig = parsed
+        }
+    }
+
+    fun stageTimeSlots(json: String) {
+        val parsed = ShiguangPayloadJson.decodeFromString(
+            ListSerializer(ShiguangTimeSlotPayload.serializer()),
+            json
+        )
+        require(parsed.isNotEmpty()) { "时间段数据为空" }
+        val sorted = parsed.sortedBy(ShiguangTimeSlotPayload::number)
+        sorted.forEachIndexed { index, slot ->
+            require(slot.number == index + 1) { "时间段编号必须从 1 连续递增" }
+            val start = parseTime(slot.startTime, "第 ${slot.number} 节 startTime")
+            val end = parseTime(slot.endTime, "第 ${slot.number} 节 endTime")
+            require(start < end) { "第 ${slot.number} 节结束时间必须晚于开始时间" }
+            if (index > 0) {
+                val previousEnd = parseTime(sorted[index - 1].endTime, "第 ${slot.number - 1} 节 endTime")
+                require(start >= previousEnd) { "时间段配置存在重叠" }
+            }
+        }
+        synchronized(lock) {
+            require(active) { "当前没有正在执行的拾光导入任务" }
+            timeSlots = parsed
+        }
+    }
+
+    fun complete(): ImportDraft {
+        val snapshot = synchronized(lock) {
+            require(active) { "当前没有正在执行的拾光导入任务" }
+            active = false
+            SessionSnapshot(
+                baseConfig = checkNotNull(baseConfig),
+                basePeriods = basePeriods,
+                courses = courses ?: error("适配器未提交课程数据"),
+                courseConfig = courseConfig,
+                timeSlots = timeSlots
+            )
+        }
+        return snapshot.toDraft()
+    }
+
+    private fun validateCourse(index: Int, course: ShiguangCoursePayload) {
+        val label = "第 ${index + 1} 门课程"
+        require(course.name.isNotBlank()) { "$label name 不能为空" }
+        require(course.day in 1..7) { "$label day 必须在 1 到 7 之间" }
+        require(course.weeks.isNotEmpty()) { "$label weeks 不能为空" }
+        require(course.weeks.all { it > 0 }) { "$label weeks 必须为正整数" }
+        val startSection = course.startSection
+        val endSection = course.endSection
+        val hasStartSection = startSection != null
+        val hasEndSection = endSection != null
+        require(hasStartSection == hasEndSection) { "$label startSection 与 endSection 必须同时提供" }
+        if (startSection != null && endSection != null) {
+            require(startSection > 0 && endSection >= startSection) {
+                "$label 节次范围无效"
+            }
+        }
+        if (course.isCustomTime) {
+            val start = parseTime(course.customStartTime, "$label customStartTime")
+            val end = parseTime(course.customEndTime, "$label customEndTime")
+            require(start < end) { "$label 自定义结束时间必须晚于开始时间" }
+        } else {
+            require(hasStartSection) { "$label 缺少节次范围" }
+        }
+    }
+
+    private data class SessionSnapshot(
+        val baseConfig: ScheduleConfigEntity,
+        val basePeriods: List<PeriodEntity>,
+        val courses: List<ShiguangCoursePayload>,
+        val courseConfig: ShiguangCourseConfigPayload?,
+        val timeSlots: List<ShiguangTimeSlotPayload>?
+    ) {
+        fun toDraft(): ImportDraft {
+            val mappedPeriods = timeSlots?.map { slot ->
+                PeriodEntity(slot.number, slot.startTime, slot.endTime, baseConfig.id)
+            } ?: basePeriods
+            require(mappedPeriods.isNotEmpty()) { "目标课表没有可用于预览的节次" }
+            val periodIndexSet = mappedPeriods.mapTo(hashSetOf(), PeriodEntity::periodIndex)
+            val mappedCourses = courses.mapIndexed { index, course ->
+                val periods = if (course.isCustomTime) {
+                    course.customTimePeriodIndexes(mappedPeriods)
+                } else {
+                    course.sectionRangeOrNull()?.toList().orEmpty()
+                }
+                require(periods.isNotEmpty()) { "第 ${index + 1} 门课程无法映射到 SleepDown 节次" }
+                require(periods.all { it in periodIndexSet }) {
+                    "第 ${index + 1} 门课程引用了不存在的节次"
+                }
+                CourseEntity(
+                    name = course.name,
+                    teacher = course.teacher.ifBlank { null },
+                    location = course.position.ifBlank { null },
+                    weekday = course.day,
+                    periods = periods,
+                    weeks = course.weeks.distinct().sorted(),
+                    weekParity = WeekParity.ALL,
+                    note = course.remark?.takeIf { it.isNotBlank() },
+                    customStartTime = course.customStartTime?.takeIf { course.isCustomTime },
+                    customEndTime = course.customEndTime?.takeIf { course.isCustomTime },
+                    // Shiguang color is a palette index, not ARGB. SleepDown keeps automatic color assignment.
+                    customColorArgb = null,
+                    scheduleId = baseConfig.id
+                )
+            }
+            val mappedConfig = courseConfig?.let { imported ->
+                baseConfig.copy(
+                    totalWeeks = imported.semesterTotalWeeks,
+                    currentWeek = baseConfig.currentWeek.coerceIn(1, imported.semesterTotalWeeks),
+                    termStartDate = imported.semesterStartDate,
+                    classDurationMinutes = imported.defaultClassDuration,
+                    breakDurationMinutes = imported.defaultBreakDuration
+                )
+            } ?: baseConfig
+            return ImportDraft(
+                config = mappedConfig,
+                periods = mappedPeriods,
+                courses = mappedCourses
+            )
+        }
+    }
+}
+
+private fun ShiguangCoursePayload.sectionRangeOrNull(): IntRange? {
+    val start = startSection ?: return null
+    val end = endSection ?: return null
+    return start..end
+}
+
+private fun ShiguangCoursePayload.customTimePeriodIndexes(periods: List<PeriodEntity>): List<Int> {
+    if (!isCustomTime) return emptyList()
+    val start = parseTime(customStartTime, "customStartTime")
+    val end = parseTime(customEndTime, "customEndTime")
+    return courseAnchorPeriodsForTimeRange(start, end, periods)
+}
+
+private fun parseTime(value: String?, label: String): LocalTime {
+    require(!value.isNullOrBlank()) { "$label 不能为空" }
+    return try {
+        LocalTime.parse(value)
+    } catch (error: Exception) {
+        throw IllegalArgumentException("$label 必须是 HH:mm", error)
+    }
+}

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangImportSession.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangImportSession.kt
@@ -5,7 +5,6 @@ import com.xiaomanjun.sleepdownschedule.PeriodEntity
 import com.xiaomanjun.sleepdownschedule.ScheduleConfigEntity
 import com.xiaomanjun.sleepdownschedule.CourseEntity
 import com.xiaomanjun.sleepdownschedule.WeekParity
-import com.xiaomanjun.sleepdownschedule.courseAnchorPeriodsForTimeRange
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import java.time.LocalTime
@@ -172,7 +171,9 @@ internal class ShiguangImportSession {
                 } else {
                     course.sectionRangeOrNull()?.toList().orEmpty()
                 }
-                require(periods.isNotEmpty()) { "第 ${index + 1} 门课程无法映射到 SleepDown 节次" }
+                if (!course.isCustomTime) {
+                    require(periods.isNotEmpty()) { "第 ${index + 1} 门课程缺少节次范围" }
+                }
                 require(periods.all { it in periodIndexSet }) {
                     "第 ${index + 1} 门课程引用了不存在的节次"
                 }
@@ -220,7 +221,11 @@ private fun ShiguangCoursePayload.customTimePeriodIndexes(periods: List<PeriodEn
     if (!isCustomTime) return emptyList()
     val start = parseTime(customStartTime, "customStartTime")
     val end = parseTime(customEndTime, "customEndTime")
-    return courseAnchorPeriodsForTimeRange(start, end, periods)
+    return periods.filter { period ->
+        val periodStart = parseTime(period.startTime, "节次 ${period.periodIndex} startTime")
+        val periodEnd = parseTime(period.endTime, "节次 ${period.periodIndex} endTime")
+        periodStart < end && periodEnd > start
+    }.map(PeriodEntity::periodIndex)
 }
 
 private fun parseTime(value: String?, label: String): LocalTime {

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWarehouseUpdater.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWarehouseUpdater.kt
@@ -15,7 +15,6 @@ import java.net.URL
 import java.net.URLEncoder
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 
 internal data class ShiguangRefreshResult(
@@ -29,6 +28,7 @@ internal object ShiguangWarehouseUpdater {
     private const val PreferencesName = "shiguang_warehouse_metadata"
     private const val LastSuccessfulRefreshKey = "last_successful_refresh"
     private const val IndexShaKey = "index_sha256"
+    private const val VersionIdKey = "version_id"
     private const val IndexUrl =
         "https://raw.githubusercontent.com/XingHeYuZhuan/shiguang_warehouse/index-pb-release/school_index.pb"
     private const val ResourceBaseUrl =
@@ -39,10 +39,10 @@ internal object ShiguangWarehouseUpdater {
     fun cachedIndexFile(context: Context): File = File(cacheRoot(context), IndexFileName)
 
     fun cachedScriptFile(context: Context, adapter: EduAdapter): File =
-        safeResourceFile(context, resourceRelativePath(adapter))
+        safeResourceFile(context, currentRemoteSnapshot(context).indexSha, resourceRelativePath(adapter))
 
     fun hasValidRemoteIndex(context: Context): Boolean = runCatching {
-        ShiguangWarehouse.parseProtocolV2Index(cachedIndexFile(context).readBytes()).isNotEmpty()
+        currentRemoteSnapshot(context).adapters.isNotEmpty()
     }.getOrDefault(false)
 
     fun isRefreshStale(context: Context, nowMillis: Long = System.currentTimeMillis()): Boolean {
@@ -53,19 +53,18 @@ internal object ShiguangWarehouseUpdater {
     suspend fun refresh(context: Context): ShiguangRefreshResult = withContext(Dispatchers.IO) {
         refreshMutex.withLock {
             val bytes = download(IndexUrl)
-            val adapters = ShiguangWarehouse.parseProtocolV2Index(bytes)
-            require(adapters.isNotEmpty()) { "远端拾光索引为空" }
-            val sha = bytes.sha256()
+            val snapshot = ShiguangWarehouse.parseProtocolV2Snapshot(bytes)
             val previousSha = preferences(context).getString(IndexShaKey, null)
             atomicWrite(cachedIndexFile(context), bytes)
             val committed = preferences(context).edit()
                 .putLong(LastSuccessfulRefreshKey, System.currentTimeMillis())
-                .putString(IndexShaKey, sha)
+                .putString(IndexShaKey, snapshot.indexSha)
+                .putString(VersionIdKey, snapshot.versionId)
                 .commit()
             check(committed) { "无法保存拾光仓库刷新时间" }
             ShiguangRefreshResult(
-                changed = previousSha != sha,
-                adapterCount = adapters.size
+                changed = previousSha != snapshot.indexSha,
+                adapterCount = snapshot.adapters.size
             )
         }
     }
@@ -74,7 +73,13 @@ internal object ShiguangWarehouseUpdater {
         withContext(Dispatchers.IO) {
             refreshMutex.withLock {
                 val relativePath = resourceRelativePath(adapter)
-                val target = safeResourceFile(context, relativePath)
+                val snapshot = currentRemoteSnapshot(context)
+                require(snapshot.adapters.any { current ->
+                    current.school.id == adapter.school.id &&
+                        current.adapterId == adapter.adapterId &&
+                        resourceRelativePath(current) == relativePath
+                }) { "当前拾光索引不再包含此适配器：${adapter.displayName}" }
+                val target = safeResourceFile(context, snapshot.indexSha, relativePath)
                 target.takeIf { it.isFile }?.readText()?.takeIf { it.isNotBlank() }?.let { return@withLock it }
 
                 val encodedPath = relativePath.split('/').joinToString("/") { segment ->
@@ -88,10 +93,11 @@ internal object ShiguangWarehouseUpdater {
         }
 
     internal fun resourceRelativePath(adapter: EduAdapter): String {
-        val path = if ('/' in adapter.assetJsPath) {
-            adapter.assetJsPath
+        val assetPath = adapter.assetJsPath.ifBlank { "${adapter.adapterId}.js" }
+        val path = if ('/' in assetPath) {
+            assetPath
         } else {
-            "${adapter.school.folder}/${adapter.assetJsPath}"
+            "${adapter.school.folder}/$assetPath"
         }
         require(path.isNotBlank()) { "拾光脚本路径为空" }
         require('\\' !in path && !path.startsWith('/')) { "非法拾光脚本路径：$path" }
@@ -107,10 +113,15 @@ internal object ShiguangWarehouseUpdater {
     private fun cacheRoot(context: Context): File =
         File(context.filesDir, CacheDirectoryName).apply { mkdirs() }
 
-    private fun safeResourceFile(context: Context, relativePath: String): File {
+    private fun currentRemoteSnapshot(context: Context) =
+        ShiguangWarehouse.parseProtocolV2Snapshot(cachedIndexFile(context).readBytes())
+
+    private fun safeResourceFile(context: Context, generation: String, relativePath: String): File {
+        require(generation.matches(Regex("[0-9a-f]{64}"))) { "非法拾光缓存 generation" }
         val resources = File(cacheRoot(context), "resources").apply { mkdirs() }
-        val target = File(resources, relativePath)
-        val rootPath = resources.canonicalFile.toPath()
+        val generationRoot = File(resources, generation).apply { mkdirs() }
+        val target = File(generationRoot, relativePath)
+        val rootPath = generationRoot.canonicalFile.toPath()
         val targetPath = target.canonicalFile.toPath()
         require(targetPath.startsWith(rootPath)) { "拾光脚本路径越界：$relativePath" }
         return target
@@ -154,7 +165,4 @@ internal object ShiguangWarehouseUpdater {
         }
     }
 
-    private fun ByteArray.sha256(): String = MessageDigest.getInstance("SHA-256")
-        .digest(this)
-        .joinToString("") { byte -> "%02x".format(byte) }
 }

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWarehouseUpdater.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWarehouseUpdater.kt
@@ -74,12 +74,18 @@ internal object ShiguangWarehouseUpdater {
             refreshMutex.withLock {
                 val relativePath = resourceRelativePath(adapter)
                 val snapshot = currentRemoteSnapshot(context)
-                require(snapshot.adapters.any { current ->
+                val existsInCurrentSnapshot = snapshot.adapters.any { current ->
                     current.school.id == adapter.school.id &&
                         current.adapterId == adapter.adapterId &&
                         resourceRelativePath(current) == relativePath
-                }) { "当前拾光索引不再包含此适配器：${adapter.displayName}" }
-                val target = safeResourceFile(context, snapshot.indexSha, relativePath)
+                }
+                val selectedGeneration = if (existsInCurrentSnapshot) {
+                    snapshot.indexSha
+                } else {
+                    adapter.warehouseGeneration.takeIf { it.matches(Regex("[0-9a-f]{64}")) }
+                        ?: snapshot.indexSha
+                }
+                val target = safeResourceFile(context, selectedGeneration, relativePath)
                 target.takeIf { it.isFile }?.readText()?.takeIf { it.isNotBlank() }?.let { return@withLock it }
 
                 val encodedPath = relativePath.split('/').joinToString("/") { segment ->

--- a/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWebRuntime.kt
+++ b/app/src/main/java/com/xiaomanjun/sleepdownschedule/feature/importing/shiguang/ShiguangWebRuntime.kt
@@ -1,0 +1,320 @@
+package com.xiaomanjun.sleepdownschedule.feature.importing.shiguang
+
+import android.net.Uri
+import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import org.json.JSONObject
+import java.io.FilterInputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URI
+import java.net.URL
+import java.util.Collections
+
+internal val ShiguangPostInterceptScript = """
+(function() {
+    var bridge = window.WebPostService;
+    if (!bridge || window._postInterceptInjected) return;
+    window._postInterceptInjected = true;
+
+    var requestIdHeader = 'X-WebView-Post-Id';
+    var requestIdParam = '_webview_post_id';
+
+    function register(id, body, contentType) {
+        try {
+            if (window.WebPostService && window.WebPostService.register) {
+                window.WebPostService.register(id, body, contentType || '');
+            }
+        } catch(e) {
+            console.error("WebPostService register error:", e);
+        }
+    }
+
+    var oldOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function(method, url) {
+        this._method = method;
+        this._url = url;
+        this._headers = {};
+        return oldOpen.apply(this, arguments);
+    };
+
+    var oldSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
+    XMLHttpRequest.prototype.setRequestHeader = function(header, value) {
+        try {
+            if (this._headers && header) this._headers[header] = value;
+            if (header && header.toLowerCase() === 'x-requested-with') return;
+        } catch(e) {
+            console.error("XHR setRequestHeader error:", e);
+        }
+        return oldSetRequestHeader.apply(this, arguments);
+    };
+
+    var oldSend = XMLHttpRequest.prototype.send;
+    XMLHttpRequest.prototype.send = function(body) {
+        try {
+            if (this._method && this._method.toUpperCase() !== 'GET' && body) {
+                var id = 'xhr_' + Date.now() + '_' + Math.random().toString(36).substr(2);
+                var contentType = (this._headers && (this._headers['Content-Type'] || this._headers['content-type'])) || '';
+                var bodyStr = '';
+                if (typeof body === 'string') {
+                    bodyStr = body;
+                } else if (window.FormData && body instanceof FormData) {
+                    if (window.URLSearchParams) {
+                        var params = new URLSearchParams();
+                        for (var pair of body.entries()) params.append(pair[0], pair[1]);
+                        bodyStr = params.toString();
+                    }
+                    if (!contentType) contentType = 'application/x-www-form-urlencoded';
+                } else if (window.URLSearchParams && body instanceof URLSearchParams) {
+                    bodyStr = body.toString();
+                    if (!contentType) contentType = 'application/x-www-form-urlencoded';
+                }
+                if (bodyStr) {
+                    register(id, bodyStr, contentType);
+                    this.setRequestHeader(requestIdHeader, id);
+                }
+            }
+        } catch(e) {
+            console.error("XHR send intercept error:", e);
+        }
+        return oldSend.apply(this, arguments);
+    };
+
+    if (window.fetch) {
+        var oldFetch = window.fetch;
+        window.fetch = function(input, init) {
+            try {
+                var options = init || {};
+                var method = options.method;
+                if (!method && input && typeof input === 'object' && input.method) method = input.method;
+                if (!method) method = 'GET';
+                var body = options.body;
+                if (method.toUpperCase() !== 'GET' && body) {
+                    var id = 'fetch_' + Date.now() + '_' + Math.random().toString(36).substr(2);
+                    var contentType = '';
+                    var headers = options.headers || (input && typeof input === 'object' ? input.headers : null);
+                    if (headers) {
+                        if (window.Headers && headers instanceof Headers) {
+                            contentType = headers.get('Content-Type') || headers.get('content-type') || '';
+                        } else if (Array.isArray(headers)) {
+                            for (var i = 0; i < headers.length; i++) {
+                                if (headers[i] && headers[i][0] && headers[i][0].toLowerCase() === 'content-type') {
+                                    contentType = headers[i][1];
+                                    break;
+                                }
+                            }
+                        } else if (typeof headers === 'object') {
+                            contentType = headers['Content-Type'] || headers['content-type'] || '';
+                        }
+                    }
+                    var bodyStr = '';
+                    if (typeof body === 'string') {
+                        bodyStr = body;
+                    } else if (window.URLSearchParams && body instanceof URLSearchParams) {
+                        bodyStr = body.toString();
+                        if (!contentType) contentType = 'application/x-www-form-urlencoded';
+                    } else if (window.FormData && body instanceof FormData) {
+                        if (window.URLSearchParams) {
+                            var p = new URLSearchParams();
+                            for (var pair of body.entries()) p.append(pair[0], pair[1]);
+                            bodyStr = p.toString();
+                        }
+                        if (!contentType) contentType = 'application/x-www-form-urlencoded';
+                    }
+                    if (bodyStr) {
+                        register(id, bodyStr, contentType);
+                        if (!options.headers) options.headers = {};
+                        if (window.Headers && options.headers instanceof Headers) {
+                            options.headers.set(requestIdHeader, id);
+                        } else if (Array.isArray(options.headers)) {
+                            options.headers.push([requestIdHeader, id]);
+                        } else if (typeof options.headers === 'object') {
+                            options.headers[requestIdHeader] = id;
+                        }
+                    }
+                }
+                return oldFetch.call(this, input, options);
+            } catch(e) {
+                console.error("Fetch intercept error:", e);
+                return oldFetch.apply(this, arguments);
+            }
+        };
+    }
+
+    document.addEventListener('submit', function(e) {
+        try {
+            var form = e.target;
+            if (!form || !form.tagName || form.tagName.toLowerCase() !== 'form') return;
+            if (!form.method || form.method.toLowerCase() !== 'post') return;
+            if (form.querySelector && form.querySelector('input[type="file"]')) return;
+            var id = 'form_' + Date.now() + '_' + Math.random().toString(36).substr(2);
+            var formData = new FormData(form);
+            var submitter = e.submitter || document.activeElement;
+            if (submitter && submitter.form === form && submitter.name) {
+                formData.append(submitter.name, submitter.value);
+            }
+            if (window.URLSearchParams) {
+                var params = new URLSearchParams(formData);
+                register(id, params.toString(), 'application/x-www-form-urlencoded');
+                var action = form.getAttribute('action') || window.location.href;
+                var separator = action.indexOf('?') !== -1 ? '&' : '?';
+                form.setAttribute('action', action + separator + requestIdParam + '=' + id);
+            }
+        } catch(err) {
+            console.error("Form submit intercept error:", err);
+        }
+    }, true);
+})();
+""".trimIndent()
+
+internal class ShiguangWebRequestInterceptor {
+    private data class RegisteredPostData(val body: String, val contentType: String)
+
+    companion object {
+        private val postBodyRegistry = Collections.synchronizedMap(mutableMapOf<String, RegisteredPostData>())
+
+        private fun registerPostData(id: String, body: String, contentType: String) {
+            postBodyRegistry[id] = RegisteredPostData(body, contentType)
+        }
+    }
+
+    private val cookieManager = CookieManager.getInstance()
+
+    fun intercept(request: WebResourceRequest, desktopMode: Boolean): WebResourceResponse? {
+        val rawUrl = request.url.toString()
+        if (!desktopMode || (!rawUrl.startsWith("http://") && !rawUrl.startsWith("https://"))) return null
+
+        val requestIdHeader = request.requestHeaders.entries
+            .firstOrNull { it.key.equals("X-WebView-Post-Id", ignoreCase = true) }
+            ?.value
+        val requestIdParam = request.url.getQueryParameter("_webview_post_id")
+        val requestId = requestIdHeader ?: requestIdParam
+        if (!request.isForMainFrame && requestId == null) return null
+
+        val url = request.url.withoutInternalPostId(requestIdParam != null)
+        val registeredData = requestId?.let(postBodyRegistry::remove)
+        if (!request.method.equals("GET", ignoreCase = true) && registeredData == null) return null
+
+        val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+            connectTimeout = 30_000
+            readTimeout = 60_000
+            instanceFollowRedirects = !request.isForMainFrame
+            requestMethod = request.method
+            request.requestHeaders.forEach { (key, value) ->
+                if (!key.equals("X-Requested-With", ignoreCase = true) &&
+                    !key.equals("X-WebView-Post-Id", ignoreCase = true) &&
+                    !key.equals("Accept-Encoding", ignoreCase = true)) {
+                    setRequestProperty(key, value)
+                }
+            }
+            setRequestProperty("Accept-Encoding", "identity")
+            cookieManager.getCookie(url)?.takeIf(String::isNotBlank)?.let { setRequestProperty("Cookie", it) }
+            registeredData?.let { data ->
+                doOutput = true
+                setRequestProperty(
+                    "Content-Type",
+                    data.contentType.ifBlank { "application/x-www-form-urlencoded" }
+                )
+                outputStream.use { it.write(data.body.toByteArray(Charsets.UTF_8)) }
+            }
+        }
+
+        return try {
+            val status = connection.responseCode
+            connection.headerFields["Set-Cookie"]?.forEach { cookieManager.setCookie(url, it) }
+            cookieManager.flush()
+            if (status in 300..399 && request.isForMainFrame) {
+                val location = connection.getHeaderField("Location")
+                connection.disconnect()
+                if (location == null) return null
+                val destination = resolveAbsoluteUrl(url, location)
+                val html = "<html><script>window.location.replace(${JSONObject.quote(destination)});</script></html>"
+                return WebResourceResponse(
+                    "text/html",
+                    "UTF-8",
+                    200,
+                    "OK",
+                    mapOf("Cache-Control" to "no-cache"),
+                    html.byteInputStream()
+                )
+            }
+
+            val contentType = connection.contentType.orEmpty()
+            val mimeType = contentType.substringBefore(';').ifBlank { "text/html" }
+            val encoding = Regex("charset=([^;]+)", RegexOption.IGNORE_CASE)
+                .find(contentType)?.groupValues?.get(1)?.trim()?.trim('"') ?: "UTF-8"
+            val responseHeaders = connection.headerFields
+                .filterKeys { it != null && !it.equals("Content-Encoding", ignoreCase = true) }
+                .mapValues { (_, values) -> values.joinToString(", ") }
+            val responseStream = connection.inputStreamOrError().disconnectWith(connection)
+            WebResourceResponse(
+                mimeType,
+                encoding,
+                status,
+                connection.responseMessage.orEmpty().ifBlank { "OK" },
+                responseHeaders,
+                responseStream
+            )
+        } catch (error: Exception) {
+            connection.disconnect()
+            null
+        }
+    }
+
+    private fun Uri.withoutInternalPostId(hasInternalId: Boolean): String {
+        if (!hasInternalId) return toString()
+        val builder = buildUpon().clearQuery()
+        queryParameterNames.forEach { name ->
+            if (name != "_webview_post_id") {
+                getQueryParameters(name).forEach { value -> builder.appendQueryParameter(name, value) }
+            }
+        }
+        return builder.build().toString()
+    }
+
+    private fun resolveAbsoluteUrl(baseUrl: String, location: String): String =
+        try {
+            URI(baseUrl).resolve(location).toString()
+        } catch (_: Exception) {
+            location
+        }
+
+    private fun HttpURLConnection.inputStreamOrError(): InputStream =
+        if (responseCode >= 400) errorStream ?: inputStream else inputStream
+
+    private fun InputStream.disconnectWith(connection: HttpURLConnection): InputStream =
+        object : FilterInputStream(this) {
+            override fun close() {
+                try {
+                    super.close()
+                } finally {
+                    connection.disconnect()
+                }
+            }
+        }
+
+    internal class WebPostService {
+        @JavascriptInterface
+        fun register(id: String, body: String, contentType: String) {
+            registerPostData(id, body, contentType)
+        }
+    }
+}
+
+internal fun WebView.installShiguangRuntime(host: ShiguangBridgeHost) {
+    addJavascriptInterface(ShiguangNativeBridge(host), "_shiguangNativeBridge")
+    addJavascriptInterface(ShiguangWebRequestInterceptor.WebPostService(), "WebPostService")
+}
+
+internal fun WebView.injectShiguangRuntime(desktopMode: Boolean) {
+    evaluateJavascript(ShiguangBridgeInitScript, null)
+    if (desktopMode) evaluateJavascript(ShiguangPostInterceptScript, null)
+}
+
+internal fun WebView.uninstallShiguangRuntime() {
+    removeJavascriptInterface("_shiguangNativeBridge")
+    removeJavascriptInterface("WebPostService")
+}


### PR DESCRIPTION
## 完成

- 以上游 `shiguangschedule@b137e350` 与 `shiguang_warehouse@16ac08e7` 为当前协议基线。
- 学校列表正式使用 Protocol V2：有效远端 index → 内置官方 v2 snapshot → 仅在 v2 全部不可用时使用 legacy YAML。
- 保留 SleepDown 自有 `AI_EDU_IMPORT`，其余学校和 adapter 均由官方 index 决定；本科、研究生、GENERAL_TOOL 与同校多 adapter 均保留。
- 官方 adapter JS 原样执行，不再做函数删除、字符串替换、前后置学校补丁或 inline rewrite。
- 新增官方 Bridge surface：
  - `window.shiguangBridgePromise`: `showAlert`、`showPrompt`、`showSingleSelection`、`saveImportedCourses`、`saveCourseConfig`、`savePresetTimeSlots`
  - `window.shiguangBridge`: `showToast`、`notifyTaskCompletion`
  - 同时提供 `AndroidBridgePromise` / `AndroidBridge` legacy aliases。
- Native 使用 `_shiguangNativeBridge.postMessage(json)` 与 `_shiguangNativeCallback(...)`；Promise 保存失败会 reject，不再 Toast 后伪装成功。
- `save*` 严格解析官方 payload 并暂存到一次性的 `ShiguangImportSession`；`notifyTaskCompletion` 只负责校验 Session、生成 `ImportDraft` 并进入现有 SleepDown 导入预览。
- 保留原有 `ImportDraft → Preview → 用户确认/取消 → 数据库` 产品链路；常规拾光不会直接写库。
- WakeUp / 星链原手动口令入口保留：同一输入框识别口令，加载当前 generation 的官方 JS 原文，并把口令作为官方 `showPrompt` 的首个回答；不恢复旧 inline 脚本。
- 对齐 Android desktop POST runtime：XHR/fetch/form POST body registry、Cookie 同步、移除 `X-Requested-With`、main-frame redirect 与请求转发。
- 远端 index 与脚本 runtime 闭环：脚本按 `indexSha` generation 缓存；同一路径在 index 更新后不会继续命中上一 generation 的旧 JS；网络失败时仅回退同路径内置官方脚本。
- 保留现有手动刷新、7 天 stale refresh、atomic index replace、上次成功缓存与 Browser Liquid UI。
- WebView 页面固定在顶栏下方的原布局，不再随滚动平移；渐变顶栏的 producer 区域改为拉伸采样当前网页顶部真实 1px 行，避免网页头部被裁切。
- 对照 Nexio 的 WebView 宿主补齐完整显示：主/弹出 WebView 使用 `MATCH_PARENT`，手机与电脑模式都由 Chromium overview 先适配当前窗口，教务 Activity 使用 `adjustResize`；严格 SSL、兼容级 Mixed Content 与 file 权限边界保持不变。
- 学校选择页不再展示 WakeUp、星链及其他 `GENERAL_TOOL`；WakeUp / 星链仍保留在 AI 手动导入的原口令入口。

## 已删除的旧业务修正

- SWU 固定节次 / 开学配置覆盖。
- `isLikelyWrongImportedPeriod`、`expandImportedPeriods`、`buildNextPeriod` 等“看起来不合理就重写”逻辑。
- WakeUp / StarLink 官方脚本删除入口函数后重新拼装的 inline runtime。
- 正式 v2 正常时混入本地 YAML 私有 adapter。
- 旧 SleepDown `EduImportBridge` 与官方 runtime 并存的双主链。

## Payload 映射边界

- 已保留：课程名、教师、地点、星期、起止节次、原始周次、自定义起止时间、备注、学期开始日、总周数、课时/课间时长、节次编号与起止时间。
- 自定义时间只关联真实重叠节次，不再吸附最近节次；无重叠时仍保留官方自定义时间。
- 官方 `color` 是拾光 palette index，不能当作 ARGB，SleepDown 使用自动配色。
- 官方 course string id、`firstDayOfWeek`、time-slot `alias` 在现有 SleepDown 模型无等价字段；本轮按约束不改 Room schema。

## Cache 顺序

1. 有效远端 Protocol V2 index
2. 当前 index generation 的远端脚本缓存
3. 按需下载官方 `main/resources/<path>`
4. 网络不可用时回退 APK 内置同路径官方脚本
5. 远端 index 无效时使用内置 v2 index
6. 仅当两个 v2 index 都不可用时使用 legacy YAML

## 验证

- `compileGithubReleaseKotlin`: BUILD SUCCESSFUL
- `assembleGithubRelease`: BUILD SUCCESSFUL（正式资源压缩、R8、lintVital、签名链路）
- APK: `1.2.2 (28)`, SHA-256 `FB768BC8910D0E189895971272A218BB43CFFCA71BECA4154C71EB965104885D`
- 当前没有连接 Android 设备；SWU、官方 component test、WakeUp/StarLink、另一所学校以及 generation 切换后的真实网络执行仍需实机确认。

## 明确未改

- AI Import 后台/网络/通知
- Day Agent
- Browser Dock 与 WebView UI
- 首页、Widget、课程管理
- 数据库 schema / migration
- 后端
